### PR TITLE
Add repo scaffolding with package.json and ESLint config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+plans/
+pulls/
+issues/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cliff Wu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,30 @@
+export default [
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        require: "readonly",
+        module: "readonly",
+        exports: "writable",
+        __dirname: "readonly",
+        __filename: "readonly",
+        Buffer: "readonly",
+        setTimeout: "readonly",
+        setInterval: "readonly",
+        clearTimeout: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    rules: {
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "no-undef": "error",
+      "no-constant-condition": "warn",
+      eqeqeq: "warn",
+      "no-throw-literal": "warn",
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@z80020100/claude-code-statusline",
+  "version": "0.1.0",
+  "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
+  "main": "lib/statusline.js",
+  "bin": {
+    "claude-code-statusline": "bin/claude-code-statusline.js"
+  },
+  "files": ["bin/", "lib/", "LICENSE", "README.md"],
+  "scripts": {
+    "check": "node test/measure-width.js --check",
+    "lint": "npx eslint .",
+    "format:check": "npx prettier --check .",
+    "test": "npm run lint && npm run format:check && npm run check",
+    "postinstall": "node -e \"console.log('\\n  Run setup to configure Claude Code automatically:\\n    claude-code-statusline setup\\n')\"",
+    "prepublishOnly": "npm test"
+  },
+  "keywords": [
+    "claude-code",
+    "statusline",
+    "status-line",
+    "cli",
+    "terminal",
+    "ansi"
+  ],
+  "license": "MIT",
+  "author": "Cliff Wu <z800201002005@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/z80020100/claude-code-statusline.git"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "bin": {
     "claude-code-statusline": "bin/claude-code-statusline.js"
   },
-  "files": ["bin/", "lib/", "LICENSE", "README.md"],
+  "files": [
+    "bin/",
+    "lib/",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "check": "node test/measure-width.js --check",
     "lint": "npx eslint .",


### PR DESCRIPTION
## Summary
- Initialize `@z80020100/claude-code-statusline` npm package repo
- Set up project foundation for extracting the custom Claude Code statusline into a standalone package

## Changes
- `.gitignore` — exclude `node_modules/`, `plans/`, `pulls/`, `issues/`
- `LICENSE` — MIT license
- `package.json` — scoped npm package with bin entry point and publish config
- `eslint.config.mjs` — ESLint flat config for CommonJS

## Test plan
- [x] `package.json` is valid JSON
- [x] `eslint.config.mjs` loads without error
- [x] Prettier format check passes