### PR TITLE
Add CLI integration tests and expand pre-commit hook test trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "check": "node test/measure-width.js --check",
+    "check": "node test/measure-width.js --check && node test/cli.js",
     "lint": "npx eslint .",
     "format:check": "npx prettier --check .",
     "test": "npm run lint && npm run format:check && npm run check",

--- a/scripts/check_lint_and_format.sh
+++ b/scripts/check_lint_and_format.sh
@@ -43,12 +43,12 @@ if [ -n "$TARGET_JS" ] || [ -n "$TARGET_PRETTIER" ]; then
     fi
 fi
 
-# ── Statusline width check ───────────────────────────
-STATUSLINE="lib/statusline.js"
-if [[ "$TARGET_JS" == *"$STATUSLINE"* ]]; then
-    echo "check: statusline width"
-    if ! node test/measure-width.js --check; then
-        echo "check: statusline width failed"
+# ── Tests (width check + CLI tests) ──────────────────
+TEST_TRIGGER=$(list_files 'lib/*.js' 'bin/*.js' 'test/*.js' 'test/fixtures/*.json') || true
+if [ -n "$TEST_TRIGGER" ]; then
+    echo "check: tests (npm run check)"
+    if ! npm run --silent check; then
+        echo "check: tests failed"
         FAILED=1
     fi
 fi

--- a/scripts/check_lint_and_format.sh
+++ b/scripts/check_lint_and_format.sh
@@ -44,7 +44,7 @@ if [ -n "$TARGET_JS" ] || [ -n "$TARGET_PRETTIER" ]; then
 fi
 
 # ── Tests (width check + CLI tests) ──────────────────
-TEST_TRIGGER=$(list_files 'lib/*.js' 'bin/*.js' 'test/*.js' 'test/fixtures/*.json') || true
+TEST_TRIGGER=$(list_files 'lib/*.js' 'bin/*.js' 'test/*.js' 'test/fixtures/*.json' 'package.json') || true
 if [ -n "$TEST_TRIGGER" ]; then
     echo "check: tests (npm run check)"
     if ! npm run --silent check; then
@@ -54,7 +54,7 @@ if [ -n "$TEST_TRIGGER" ]; then
 fi
 
 # ── Shell: shellcheck + shfmt ─────────────────────────
-TARGET_SH=$(list_files '*.sh') || true
+TARGET_SH=$(list_files '*.sh' '.githooks/*') || true
 
 if [ -n "$TARGET_SH" ]; then
     if require_cmd shellcheck "brew install shellcheck"; then

--- a/scripts/fix_lint_and_format.sh
+++ b/scripts/fix_lint_and_format.sh
@@ -34,7 +34,7 @@ if [ -n "$TARGET_JS" ] || [ -n "$TARGET_PRETTIER" ]; then
 fi
 
 # ── Shell: shfmt ──────────────────────────────────────
-TARGET_SH=$(list_files '*.sh') || true
+TARGET_SH=$(list_files '*.sh' '.githooks/*') || true
 
 if [ -n "$TARGET_SH" ]; then
     if require_cmd shfmt "brew install shfmt"; then

--- a/test/cli.js
+++ b/test/cli.js
@@ -48,6 +48,15 @@ function withTmpHome(fn) {
   }
 }
 
+function seedSettings(tmp, data) {
+  const dir = path.join(tmp, ".claude");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "settings.json"),
+    JSON.stringify(data) + "\n",
+  );
+}
+
 // ── --version ────────────────────────────────────────
 
 test("--version prints package version", () => {
@@ -137,15 +146,11 @@ test("setup --uninstall on empty settings reports no changes", () => {
 
 test("setup preserves existing settings keys", () => {
   withTmpHome((tmp) => {
-    const dir = path.join(tmp, ".claude");
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, "settings.json"),
-      JSON.stringify({ existingKey: "value" }) + "\n",
-    );
-    run(["setup"], { env: { ...process.env, HOME: tmp } });
+    seedSettings(tmp, { existingKey: "value" });
+    const env = { ...process.env, HOME: tmp };
+    run(["setup"], { env });
     const settings = JSON.parse(
-      fs.readFileSync(path.join(dir, "settings.json"), "utf8"),
+      fs.readFileSync(path.join(tmp, ".claude", "settings.json"), "utf8"),
     );
     assert(settings.existingKey === "value", "existing key was lost");
     assert(
@@ -157,19 +162,14 @@ test("setup preserves existing settings keys", () => {
 
 test("setup --uninstall preserves other settings keys", () => {
   withTmpHome((tmp) => {
+    seedSettings(tmp, {
+      otherKey: 42,
+      statusLine: { type: "command", command: "claude-code-statusline" },
+    });
     const env = { ...process.env, HOME: tmp };
-    const dir = path.join(tmp, ".claude");
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, "settings.json"),
-      JSON.stringify({
-        otherKey: 42,
-        statusLine: { type: "command", command: "claude-code-statusline" },
-      }) + "\n",
-    );
     run(["setup", "--uninstall"], { env });
     const settings = JSON.parse(
-      fs.readFileSync(path.join(dir, "settings.json"), "utf8"),
+      fs.readFileSync(path.join(tmp, ".claude", "settings.json"), "utf8"),
     );
     assert(!settings.statusLine, "statusLine should be removed");
     assert(settings.otherKey === 42, "other key was lost");
@@ -178,20 +178,17 @@ test("setup --uninstall preserves other settings keys", () => {
 
 test("setup does not overwrite different statusLine without confirmation", () => {
   withTmpHome((tmp) => {
-    const dir = path.join(tmp, ".claude");
-    fs.mkdirSync(dir, { recursive: true });
-    const original = { statusLine: { type: "command", command: "other-tool" } };
-    fs.writeFileSync(
-      path.join(dir, "settings.json"),
-      JSON.stringify(original) + "\n",
-    );
-    const out = run(["setup"], { env: { ...process.env, HOME: tmp } });
+    seedSettings(tmp, {
+      statusLine: { type: "command", command: "other-tool" },
+    });
+    const env = { ...process.env, HOME: tmp };
+    const out = run(["setup"], { env });
     assert(
       out.includes("Current statusLine setting"),
       "missing prompt message",
     );
     const settings = JSON.parse(
-      fs.readFileSync(path.join(dir, "settings.json"), "utf8"),
+      fs.readFileSync(path.join(tmp, ".claude", "settings.json"), "utf8"),
     );
     assert(
       settings.statusLine.command === "other-tool",

--- a/test/cli.js
+++ b/test/cli.js
@@ -135,6 +135,71 @@ test("setup --uninstall on empty settings reports no changes", () => {
   });
 });
 
+test("setup preserves existing settings keys", () => {
+  withTmpHome((tmp) => {
+    const dir = path.join(tmp, ".claude");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "settings.json"),
+      JSON.stringify({ existingKey: "value" }) + "\n",
+    );
+    run(["setup"], { env: { ...process.env, HOME: tmp } });
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(dir, "settings.json"), "utf8"),
+    );
+    assert(settings.existingKey === "value", "existing key was lost");
+    assert(
+      settings.statusLine?.command === "claude-code-statusline",
+      "statusLine not added",
+    );
+  });
+});
+
+test("setup --uninstall preserves other settings keys", () => {
+  withTmpHome((tmp) => {
+    const env = { ...process.env, HOME: tmp };
+    const dir = path.join(tmp, ".claude");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "settings.json"),
+      JSON.stringify({
+        otherKey: 42,
+        statusLine: { type: "command", command: "claude-code-statusline" },
+      }) + "\n",
+    );
+    run(["setup", "--uninstall"], { env });
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(dir, "settings.json"), "utf8"),
+    );
+    assert(!settings.statusLine, "statusLine should be removed");
+    assert(settings.otherKey === 42, "other key was lost");
+  });
+});
+
+test("setup does not overwrite different statusLine without confirmation", () => {
+  withTmpHome((tmp) => {
+    const dir = path.join(tmp, ".claude");
+    fs.mkdirSync(dir, { recursive: true });
+    const original = { statusLine: { type: "command", command: "other-tool" } };
+    fs.writeFileSync(
+      path.join(dir, "settings.json"),
+      JSON.stringify(original) + "\n",
+    );
+    const out = run(["setup"], { env: { ...process.env, HOME: tmp } });
+    assert(
+      out.includes("Current statusLine setting"),
+      "missing prompt message",
+    );
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(dir, "settings.json"), "utf8"),
+    );
+    assert(
+      settings.statusLine.command === "other-tool",
+      "statusLine was overwritten without confirmation",
+    );
+  });
+});
+
 // ── summary ──────────────────────────────────────────
 
 console.log();

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+// CLI integration tests.
+// Usage: node test/cli.js
+//   Runs all tests and exits with code 1 on failure.
+
+"use strict";
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const CLI = path.join(__dirname, "..", "bin", "claude-code-statusline.js");
+const PKG = require("../package.json");
+
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`\x1b[38;5;114m\u2713\x1b[0m ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`\x1b[38;5;167m\u2717\x1b[0m ${name}`);
+    console.log(`  ${err.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function run(args = [], opts = {}) {
+  return execFileSync("node", [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 10000,
+    ...opts,
+  });
+}
+
+function withTmpHome(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cli-test-"));
+  try {
+    fn(tmp);
+  } finally {
+    fs.rmSync(tmp, { recursive: true });
+  }
+}
+
+// ── --version ────────────────────────────────────────
+
+test("--version prints package version", () => {
+  assert(run(["--version"]).trim() === PKG.version, "version mismatch");
+});
+
+test("-v prints package version", () => {
+  assert(run(["-v"]).trim() === PKG.version, "version mismatch");
+});
+
+// ── --help ───────────────────────────────────────────
+
+test("--help prints complete help output", () => {
+  const out = run(["--help"]);
+  assert(out.includes(`${PKG.name} v${PKG.version}`), "missing name/version");
+  assert(out.includes(PKG.description), "missing description");
+  assert(out.includes("Usage:"), "missing Usage:");
+  assert(out.includes(PKG.author), "missing author");
+  assert(out.includes(PKG.license), "missing license");
+});
+
+test("-h prints help", () => {
+  assert(run(["-h"]).includes("Usage:"), "missing Usage:");
+});
+
+// ── stdin render ─────────────────────────────────────
+
+test("stdin with valid JSON renders model name", () => {
+  const input = JSON.stringify({ model: { display_name: "Test Model" } });
+  assert(run([], { input }).includes("Test Model"), "missing model name");
+});
+
+test("stdin with invalid JSON exits silently", () => {
+  const out = run([], { input: "not json" });
+  assert(out === "", `expected empty output but got "${out}"`);
+});
+
+// ── setup / uninstall ────────────────────────────────
+
+test("setup creates settings.json with statusLine", () => {
+  withTmpHome((tmp) => {
+    run(["setup"], { env: { ...process.env, HOME: tmp } });
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmp, ".claude", "settings.json"), "utf8"),
+    );
+    assert(
+      settings.statusLine?.command === "claude-code-statusline",
+      "statusLine.command not set",
+    );
+    assert(settings.statusLine?.type === "command", "statusLine.type not set");
+  });
+});
+
+test("setup reports already configured on second run", () => {
+  withTmpHome((tmp) => {
+    const env = { ...process.env, HOME: tmp };
+    run(["setup"], { env });
+    assert(
+      run(["setup"], { env }).includes("Already configured"),
+      "missing already-configured message",
+    );
+  });
+});
+
+test("setup --uninstall removes statusLine", () => {
+  withTmpHome((tmp) => {
+    const env = { ...process.env, HOME: tmp };
+    run(["setup"], { env });
+    run(["setup", "--uninstall"], { env });
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmp, ".claude", "settings.json"), "utf8"),
+    );
+    assert(!settings.statusLine, "statusLine should be removed");
+  });
+});
+
+test("setup --uninstall on empty settings reports no changes", () => {
+  withTmpHome((tmp) => {
+    assert(
+      run(["setup", "--uninstall"], {
+        env: { ...process.env, HOME: tmp },
+      }).includes("No statusLine setting found"),
+      "missing no-setting message",
+    );
+  });
+});
+
+// ── summary ──────────────────────────────────────────
+
+console.log();
+if (failed) {
+  console.log(`\x1b[38;5;167m${failed} test(s) failed.\x1b[0m`);
+} else {
+  console.log(`\x1b[38;5;114mAll tests passed.\x1b[0m`);
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add CLI integration tests for help and version flags and setup commands
- Expand pre-commit hook to trigger tests on lib and bin and test file changes
- Include `.githooks` in shell lint and `package.json` in test trigger

## Changes
- `test/cli.js` — integration tests (13 test cases)
- `scripts/check_lint_and_format.sh` — include `.githooks` in shell lint and add test trigger
- `scripts/fix_lint_and_format.sh` — include `.githooks` in shell lint
- `package.json` — add `check` script alias

## Test plan
- [x] `npm run check` — 13 tests pass
- [x] Pre-commit hook runs tests when `test/` or `lib/` or `bin/` files change