### PR TITLE
Add npm run simulate script for worst-case rendering preview

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -102,6 +102,7 @@ npm install
 npm test                    # lint + フォーマットチェック + 幅チェック + CLI テスト
 npm run check               # 幅チェック + CLI テストのみ
 npm run lint                # ESLint のみ
+npm run simulate            # worst-case ステータスラインを描画し幅レポートを表示
 ```
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ npm install
 npm test                    # lint + format check + width check + CLI tests
 npm run check               # width check + CLI tests only
 npm run lint                # ESLint only
+npm run simulate            # render worst-case status line with width report
 ```
 
 ## License

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -102,6 +102,7 @@ npm install
 npm test                    # lint + 格式檢查 + 寬度檢查 + CLI 測試
 npm run check               # 寬度檢查 + CLI 測試
 npm run lint                # 僅 ESLint
+npm run simulate            # 渲染 worst-case 狀態列並顯示寬度報告
 ```
 
 ## 授權

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "README.md"
   ],
   "scripts": {
+    "simulate": "node test/measure-width.js",
     "check": "node test/measure-width.js --check && node test/cli.js",
     "lint": "npx eslint .",
     "format:check": "npx prettier --check .",


### PR DESCRIPTION
## Summary
- Add `npm run simulate` script to render worst-case status line output with width report
- Document the new script in all three README language versions (EN, zh-TW, ja)

## Changes
- `package.json` — add `simulate` script (`node test/measure-width.js` without `--check`)
- `README.md` — add `npm run simulate` to Development section
- `README.zh-TW.md` — add `npm run simulate` to Development section
- `README.ja.md` — add `npm run simulate` to Development section

## Test plan
- [x] `npm run simulate` renders output and width report
- [x] `npm test` passes (lint + format + width + CLI tests)