### PR TITLE
Add Node.js and npm version badges to READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,7 @@
 # claude-code-statusline
 
+[![Node.js](https://img.shields.io/badge/Node.js-≥20-green)](https://nodejs.org/) [![npm](https://img.shields.io/npm/v/@z80020100/claude-code-statusline)](https://www.npmjs.com/package/@z80020100/claude-code-statusline)
+
 [English](README.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md)
 
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 用カスタムステータスライン — モデル情報、コンテキスト使用量グラデーションバー、トークン統計、コスト、Git ステータス、レート制限を表示します。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # claude-code-statusline
 
+[![Node.js](https://img.shields.io/badge/Node.js-≥20-green)](https://nodejs.org/) [![npm](https://img.shields.io/npm/v/@z80020100/claude-code-statusline)](https://www.npmjs.com/package/@z80020100/claude-code-statusline)
+
 [English](https://github.com/z80020100/claude-code-statusline/blob/main/README.md) | [繁體中文](https://github.com/z80020100/claude-code-statusline/blob/main/README.zh-TW.md) | [日本語](https://github.com/z80020100/claude-code-statusline/blob/main/README.ja.md)
 
 Custom status line for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — model info, context usage gradient bar, token stats, cost, git status, and rate limits.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,5 +1,7 @@
 # claude-code-statusline
 
+[![Node.js](https://img.shields.io/badge/Node.js-≥20-green)](https://nodejs.org/) [![npm](https://img.shields.io/npm/v/@z80020100/claude-code-statusline)](https://www.npmjs.com/package/@z80020100/claude-code-statusline)
+
 [English](README.md) | [繁體中文](README.zh-TW.md) | [日本語](README.ja.md)
 
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 的自訂狀態列 — 顯示模型資訊、上下文使用量漸層條、Token 統計、費用、Git 狀態和速率限制。


### PR DESCRIPTION
## Summary
- Add shields.io badges (Node.js >=20 and npm version) to all three README files
- Badges link to nodejs.org and the npm package page respectively

## Changes
- `README.md` — add Node.js and npm version badges between title and language switcher
- `README.zh-TW.md` — same
- `README.ja.md` — same

## Test plan
- [x] `npm run check` passes (lint + format + 13 CLI tests)
- [x] Badges render correctly on GitHub after push