### PR TITLE
Add publish workflow for npm release on GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm test
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that publishes to npm with `--provenance` when a GitHub Release is created
- Enables automated npm publishing with supply chain transparency

## Changes
- `.github/workflows/publish.yml` — publish workflow triggered by `release: published` event with Node 20 and `npm publish --provenance`

## Test plan
- [x] `actionlint` validates workflow syntax
- [x] `npm run check` passes (lint + format + 13 CLI tests)
- [ ] Workflow triggers correctly on GitHub Release creation (requires release)