### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "main": "lib/statusline.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump package version from 0.1.0 to 1.0.0

## Test plan
- [x] `npm run check` passes (lint + format + 13 CLI tests)