### PR TITLE
Resolve effort level from settings.env before process.env

### DIFF
--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -359,9 +359,11 @@ function render(data, options = {}) {
       } catch {}
       if (!useSettingsCache) {
         const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+        // settings.env before process.env: process.env is inherited at Claude
+        // Code startup and may be stale after runtime settings.env changes.
         const envEffort =
-          process.env.CLAUDE_CODE_EFFORT_LEVEL ||
-          settings.env?.CLAUDE_CODE_EFFORT_LEVEL;
+          settings.env?.CLAUDE_CODE_EFFORT_LEVEL ??
+          process.env.CLAUDE_CODE_EFFORT_LEVEL;
         effort = envEffort || settings.effortLevel || "default";
         fs.writeFileSync(
           settingsCacheFile,


### PR DESCRIPTION
## Summary
- `/set-effort` (and any other runtime edit to `~/.claude/settings.json` `env.CLAUDE_CODE_EFFORT_LEVEL`) now reflects in the statusline immediately
- Previously the resolver consulted `process.env` first which is a snapshot inherited at Claude Code startup and stale after runtime changes

## Changes
- `lib/statusline.js` — read `settings.env.CLAUDE_CODE_EFFORT_LEVEL` before falling back to `process.env.CLAUDE_CODE_EFFORT_LEVEL` and switch the chain to `??` so an explicit empty string in `settings.env` still defers to the next fallback through the existing `||` cascade

Resolution priority for effort level:

```
settings.env.CLAUDE_CODE_EFFORT_LEVEL
  → process.env.CLAUDE_CODE_EFFORT_LEVEL
    → settings.effortLevel
      → "default"
```

## Test plan
- [x] `npm run check` passes (lint + format + 38 tests)
- [ ] `~/.claude/skills/set-effort/set_effort.sh medium` followed by a fresh statusline render shows `medium` without restarting Claude Code