### PR TITLE
Rework effort indicator with source marker and official palette

### DIFF
--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -45,6 +45,7 @@ const ICON_SETS = {
  * @param {object} [options] - Overrides for testability and cross-platform
  * @param {object} [options.git] - { branch, dirty, isWorktree, diffAdded, diffRemoved }
  * @param {string} [options.effort] - Effort level override
+ * @param {string} [options.effortSource] - "auto" | "explicit" | "lockedAuto" | "lockedExplicit"
  * @param {string} [options.sandboxMode] - Sandbox mode override ("", "auto", "on")
  * @param {string} [options.iconMode] - Icon mode override ("nerd" or "unicode")
  * @param {string} [options.home] - Home directory override
@@ -339,42 +340,60 @@ function render(data, options = {}) {
     }
   }
 
-  // ── Effort level ───────────────────────────────────
-  // Priority: data.effort.level (live session, v2.1.90+) → env
-  // CLAUDE_CODE_EFFORT_LEVEL → settings.effortLevel → "auto"
+  // ── Effort level + source ──────────────────────────
+  // Display value: data.effort.level (live, v2.1.90+) → settings/env fallback
+  // Source enum drives auto→ prefix and underline marker:
+  //   "lockedAuto"     env var is "auto"   → underline "auto" prefix
+  //   "lockedExplicit" env var is a level  → underline the level name
+  //   "explicit"       settings.effortLevel set → no decoration
+  //   "auto"           neither set         → "auto→{level}" prefix
   let effort = "auto";
+  let effortSource = "auto";
   if (options.effort !== undefined) {
     effort = options.effort;
-  } else if (data.effort?.level) {
-    effort = data.effort.level;
+    effortSource = options.effortSource ?? "auto";
   } else {
+    if (data.effort?.level) effort = data.effort.level;
     const settingsPath = path.join(home, ".claude", "settings.json");
     const settingsCacheFile = tmpCacheFile("settings");
     try {
       const mtime = fs.statSync(settingsPath).mtimeMs;
-      let useSettingsCache = false;
+      let cachedSource;
+      let cachedFallback;
       try {
         const cached = JSON.parse(fs.readFileSync(settingsCacheFile, "utf8"));
-        if (cached.mtime === mtime) {
-          // Migrate legacy "default" cached by older versions
-          effort = cached.effort === "default" ? "auto" : cached.effort;
-          useSettingsCache = true;
+        if (cached.mtime === mtime && typeof cached.source === "string") {
+          cachedSource = cached.source;
+          cachedFallback = cached.fallback;
         }
       } catch {}
-      if (!useSettingsCache) {
+      if (cachedSource === undefined) {
         const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
         // settings.env before process.env: process.env is inherited at Claude
         // Code startup and may be stale after runtime settings.env changes.
         const envEffort =
           settings.env?.CLAUDE_CODE_EFFORT_LEVEL ??
           process.env.CLAUDE_CODE_EFFORT_LEVEL;
-        effort = envEffort || settings.effortLevel || "auto";
+        if (envEffort) {
+          cachedSource = envEffort === "auto" ? "lockedAuto" : "lockedExplicit";
+        } else if (settings.effortLevel && settings.effortLevel !== "auto") {
+          cachedSource = "explicit";
+        } else {
+          cachedSource = "auto";
+        }
+        cachedFallback = envEffort || settings.effortLevel || null;
         fs.writeFileSync(
           settingsCacheFile,
-          JSON.stringify({ mtime, effort }),
+          JSON.stringify({
+            mtime,
+            source: cachedSource,
+            fallback: cachedFallback,
+          }),
           "utf8",
         );
       }
+      effortSource = cachedSource;
+      if (effort === "auto" && cachedFallback) effort = cachedFallback;
     } catch {}
   }
 
@@ -423,15 +442,36 @@ function render(data, options = {}) {
     }
   }
 
-  const effortDisplay = {
-    max: `${bold}${red}\u25CF ${effort}${reset}`,
-    xhigh: `${red}\u25CF ${effort}${reset}`,
-    high: `${coral}\u25CF ${effort}${reset}`,
-    medium: `${gold}\u25D1 ${effort}${reset}`,
-    low: `${green}\u25D4 ${effort}${reset}`,
-    auto: `${dim}\u25D1 ${effort}${reset}`,
+  // Color + symbol per level (intensity spectrum). Underline marks env-locked.
+  const effortStyle = {
+    max: { color: `${bold}${red}`, symbol: "\u25CF" },
+    xhigh: { color: red, symbol: "\u25CF" },
+    high: { color: coral, symbol: "\u25CF" },
+    medium: { color: gold, symbol: "\u25D1" },
+    low: { color: green, symbol: "\u25D4" },
+    auto: { color: dim, symbol: "\u25D1" },
   };
-  const effortStr = effortDisplay[effort] ?? effortDisplay.auto;
+  const { color: effortColor, symbol: effortSymbol } =
+    effortStyle[effort] ?? effortStyle.auto;
+  const underline = "\x1b[4m";
+  const noUnderline = "\x1b[24m";
+  const lock = (text) => `${underline}${text}${noUnderline}`;
+  let effortContent;
+  if (effort === "auto") {
+    effortContent =
+      effortSource === "lockedAuto" || effortSource === "lockedExplicit"
+        ? lock("auto")
+        : "auto";
+  } else if (effortSource === "lockedExplicit") {
+    effortContent = lock(effort);
+  } else if (effortSource === "lockedAuto") {
+    effortContent = `${lock("auto")}\u2192${effort}`;
+  } else if (effortSource === "auto") {
+    effortContent = `auto\u2192${effort}`;
+  } else {
+    effortContent = effort;
+  }
+  const effortStr = `${effortColor}${effortSymbol} ${effortContent}${reset}`;
 
   // ── Rate limit usage (native field, v2.1.80+) ──────
   const usageData = data.rate_limits || null;

--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -140,7 +140,7 @@ function render(data, options = {}) {
   const gray = "\x1b[38;5;247m"; // muted labels, token counts
   const darkGray = "\x1b[38;5;239m"; // separators, empty bar segments
   // Semantic accent
-  const violet = "\x1b[38;5;141m"; // primary accent: effort, branch
+  const violet = "\x1b[38;5;141m"; // primary accent: branch
   const blue = "\x1b[38;5;75m"; // info: cwd path, agent
   const dimBlue = "\x1b[38;5;68m"; // subdued: project path
   const teal = "\x1b[38;5;116m"; // secondary: cost, worktree
@@ -340,8 +340,8 @@ function render(data, options = {}) {
   }
 
   // ── Effort level (cached by mtime) ─────────────────
-  // Priority: env CLAUDE_CODE_EFFORT_LEVEL → settings.effortLevel → "default"
-  let effort = "default";
+  // Priority: env CLAUDE_CODE_EFFORT_LEVEL → settings.effortLevel → "auto"
+  let effort = "auto";
   if (options.effort !== undefined) {
     effort = options.effort;
   } else {
@@ -353,7 +353,8 @@ function render(data, options = {}) {
       try {
         const cached = JSON.parse(fs.readFileSync(settingsCacheFile, "utf8"));
         if (cached.mtime === mtime) {
-          effort = cached.effort;
+          // Migrate legacy "default" cached by older versions
+          effort = cached.effort === "default" ? "auto" : cached.effort;
           useSettingsCache = true;
         }
       } catch {}
@@ -364,7 +365,7 @@ function render(data, options = {}) {
         const envEffort =
           settings.env?.CLAUDE_CODE_EFFORT_LEVEL ??
           process.env.CLAUDE_CODE_EFFORT_LEVEL;
-        effort = envEffort || settings.effortLevel || "default";
+        effort = envEffort || settings.effortLevel || "auto";
         fs.writeFileSync(
           settingsCacheFile,
           JSON.stringify({ mtime, effort }),
@@ -420,13 +421,14 @@ function render(data, options = {}) {
   }
 
   const effortDisplay = {
-    max: `${red}\u25CF ${effort}${reset}`,
-    high: `${violet}\u25CF ${effort}${reset}`,
-    medium: `${dim}\u25D1 ${effort}${reset}`,
-    default: `${dim}\u25D1 ${effort}${reset}`,
-    low: `${dim}\u25D4 ${effort}${reset}`,
+    max: `${bold}${red}\u25CF ${effort}${reset}`,
+    xhigh: `${red}\u25CF ${effort}${reset}`,
+    high: `${coral}\u25CF ${effort}${reset}`,
+    medium: `${gold}\u25D1 ${effort}${reset}`,
+    low: `${green}\u25D4 ${effort}${reset}`,
+    auto: `${dim}\u25D1 ${effort}${reset}`,
   };
-  const effortStr = effortDisplay[effort] ?? effortDisplay.default;
+  const effortStr = effortDisplay[effort] ?? effortDisplay.auto;
 
   // ── Rate limit usage (native field, v2.1.80+) ──────
   const usageData = data.rate_limits || null;

--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -339,11 +339,14 @@ function render(data, options = {}) {
     }
   }
 
-  // ── Effort level (cached by mtime) ─────────────────
-  // Priority: env CLAUDE_CODE_EFFORT_LEVEL → settings.effortLevel → "auto"
+  // ── Effort level ───────────────────────────────────
+  // Priority: data.effort.level (live session, v2.1.90+) → env
+  // CLAUDE_CODE_EFFORT_LEVEL → settings.effortLevel → "auto"
   let effort = "auto";
   if (options.effort !== undefined) {
     effort = options.effort;
+  } else if (data.effort?.level) {
+    effort = data.effort.level;
   } else {
     const settingsPath = path.join(home, ".claude", "settings.json");
     const settingsCacheFile = tmpCacheFile("settings");

--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -141,7 +141,8 @@ function render(data, options = {}) {
   const gray = "\x1b[38;5;247m"; // muted labels, token counts
   const darkGray = "\x1b[38;5;239m"; // separators, empty bar segments
   // Semantic accent
-  const violet = "\x1b[38;5;141m"; // primary accent: branch
+  const violet = "\x1b[38;5;141m"; // primary accent: branch, effort xhigh
+  const lavender = "\x1b[38;5;147m"; // effort high
   const blue = "\x1b[38;5;75m"; // info: cwd path, agent
   const dimBlue = "\x1b[38;5;68m"; // subdued: project path
   const teal = "\x1b[38;5;116m"; // secondary: cost, worktree
@@ -442,13 +443,15 @@ function render(data, options = {}) {
     }
   }
 
-  // Color + symbol per level (intensity spectrum). Underline marks env-locked.
+  // Per-level color + symbol. Mapped from Claude Code's rendering:
+  // low=gold, medium=green, high=lavender, xhigh=violet (branch color),
+  // max=bold red. Underline marks env-locked.
   const effortStyle = {
     max: { color: `${bold}${red}`, symbol: "\u25CF" },
-    xhigh: { color: red, symbol: "\u25CF" },
-    high: { color: coral, symbol: "\u25CF" },
-    medium: { color: gold, symbol: "\u25D1" },
-    low: { color: green, symbol: "\u25D4" },
+    xhigh: { color: violet, symbol: "\u25CF" },
+    high: { color: lavender, symbol: "\u25CF" },
+    medium: { color: green, symbol: "\u25D1" },
+    low: { color: gold, symbol: "\u25D4" },
     auto: { color: dim, symbol: "\u25D1" },
   };
   const { color: effortColor, symbol: effortSymbol } =

--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -342,11 +342,11 @@ function render(data, options = {}) {
 
   // ── Effort level + source ──────────────────────────
   // Display value: data.effort.level (live, v2.1.90+) → settings/env fallback
-  // Source enum drives auto→ prefix and underline marker:
-  //   "lockedAuto"     env var is "auto"   → underline "auto" prefix
+  // Source enum drives the "auto" prefix and underline marker:
+  //   "lockedAuto"     env var is "auto"   → dim+underline "auto" before level
   //   "lockedExplicit" env var is a level  → underline the level name
   //   "explicit"       settings.effortLevel set → no decoration
-  //   "auto"           neither set         → "auto→{level}" prefix
+  //   "auto"           neither set         → dim "auto" before level
   let effort = "auto";
   let effortSource = "auto";
   if (options.effort !== undefined) {
@@ -456,22 +456,18 @@ function render(data, options = {}) {
   const underline = "\x1b[4m";
   const noUnderline = "\x1b[24m";
   const lock = (text) => `${underline}${text}${noUnderline}`;
-  let effortContent;
-  if (effort === "auto") {
-    effortContent =
-      effortSource === "lockedAuto" || effortSource === "lockedExplicit"
-        ? lock("auto")
-        : "auto";
-  } else if (effortSource === "lockedExplicit") {
-    effortContent = lock(effort);
-  } else if (effortSource === "lockedAuto") {
-    effortContent = `${lock("auto")}\u2192${effort}`;
-  } else if (effortSource === "auto") {
-    effortContent = `auto\u2192${effort}`;
-  } else {
-    effortContent = effort;
-  }
-  const effortStr = `${effortColor}${effortSymbol} ${effortContent}${reset}`;
+  // Color carries the source/level separation; no glyph between them.
+  const isAutoResolved =
+    effort !== "auto" &&
+    (effortSource === "auto" || effortSource === "lockedAuto");
+  const autoText = effortSource === "lockedAuto" ? lock("auto") : "auto";
+  const levelText = effortSource === "lockedExplicit" ? lock(effort) : effort;
+  const effortStr =
+    effort === "auto"
+      ? `${effortColor}${effortSymbol} ${autoText}${reset}`
+      : isAutoResolved
+        ? `${effortColor}${effortSymbol}${reset} ${dim}${autoText}${reset} ${effortColor}${levelText}${reset}`
+        : `${effortColor}${effortSymbol} ${levelText}${reset}`;
 
   // ── Rate limit usage (native field, v2.1.80+) ──────
   const usageData = data.rate_limits || null;

--- a/test/cli.js
+++ b/test/cli.js
@@ -96,6 +96,7 @@ test("stdin with invalid JSON exits silently", () => {
 });
 
 const UNDERLINE = "\x1b[4m";
+const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
 
 test("stdin effort.level overrides settings.effortLevel", () => {
   withTmpHome((tmp) => {
@@ -118,12 +119,15 @@ test("effort source: settings.effortLevel set renders explicit (no marker)", () 
       effort: { level: "high" },
     });
     const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
-    assert(!out.includes("auto→"), `unexpected auto→ prefix: ${out}`);
+    assert(
+      !stripAnsi(out).includes("auto high"),
+      `unexpected auto prefix: ${out}`,
+    );
     assert(!out.includes(UNDERLINE), `unexpected underline: ${out}`);
   });
 });
 
-test("effort source: no env, no effortLevel renders auto→ prefix", () => {
+test("effort source: no env, no effortLevel renders auto prefix", () => {
   withTmpHome((tmp) => {
     seedSettings(tmp, {});
     const input = JSON.stringify({
@@ -131,7 +135,10 @@ test("effort source: no env, no effortLevel renders auto→ prefix", () => {
       effort: { level: "xhigh" },
     });
     const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
-    assert(out.includes("auto→xhigh"), `expected auto→xhigh prefix: ${out}`);
+    assert(
+      stripAnsi(out).includes("auto xhigh"),
+      `expected "auto xhigh" prefix: ${out}`,
+    );
     assert(!out.includes(UNDERLINE), `unexpected underline: ${out}`);
   });
 });
@@ -145,7 +152,10 @@ test("effort source: env-locked level underlines the level", () => {
     });
     const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
     assert(out.includes(`${UNDERLINE}high`), `expected underline+high: ${out}`);
-    assert(!out.includes("auto→"), `unexpected auto→ prefix: ${out}`);
+    assert(
+      !stripAnsi(out).includes("auto high"),
+      `unexpected auto prefix: ${out}`,
+    );
   });
 });
 
@@ -158,7 +168,10 @@ test("effort source: env-locked auto underlines auto and shows resolved level", 
     });
     const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
     assert(out.includes(`${UNDERLINE}auto`), `expected underline+auto: ${out}`);
-    assert(out.includes("→xhigh"), `expected →xhigh after auto: ${out}`);
+    assert(
+      stripAnsi(out).includes("auto xhigh"),
+      `expected "auto xhigh": ${out}`,
+    );
   });
 });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -95,6 +95,19 @@ test("stdin with invalid JSON exits silently", () => {
   assert(out === "", `expected empty output but got "${out}"`);
 });
 
+test("stdin effort.level overrides settings.effortLevel", () => {
+  withTmpHome((tmp) => {
+    seedSettings(tmp, { effortLevel: "low" });
+    const input = JSON.stringify({
+      model: { display_name: "Test Model" },
+      effort: { level: "xhigh" },
+    });
+    const out = run([], { input, env: { ...process.env, HOME: tmp } });
+    assert(out.includes("xhigh"), `expected "xhigh" in output, got: ${out}`);
+    assert(!out.includes(" low"), `unexpected "low" in output: ${out}`);
+  });
+});
+
 // ── setup / uninstall ────────────────────────────────
 
 test("setup creates settings.json with statusLine", () => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -95,6 +95,8 @@ test("stdin with invalid JSON exits silently", () => {
   assert(out === "", `expected empty output but got "${out}"`);
 });
 
+const UNDERLINE = "\x1b[4m";
+
 test("stdin effort.level overrides settings.effortLevel", () => {
   withTmpHome((tmp) => {
     seedSettings(tmp, { effortLevel: "low" });
@@ -102,9 +104,61 @@ test("stdin effort.level overrides settings.effortLevel", () => {
       model: { display_name: "Test Model" },
       effort: { level: "xhigh" },
     });
-    const out = run([], { input, env: { ...process.env, HOME: tmp } });
+    const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
     assert(out.includes("xhigh"), `expected "xhigh" in output, got: ${out}`);
     assert(!out.includes(" low"), `unexpected "low" in output: ${out}`);
+  });
+});
+
+test("effort source: settings.effortLevel set renders explicit (no marker)", () => {
+  withTmpHome((tmp) => {
+    seedSettings(tmp, { effortLevel: "high" });
+    const input = JSON.stringify({
+      model: { display_name: "M" },
+      effort: { level: "high" },
+    });
+    const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
+    assert(!out.includes("auto→"), `unexpected auto→ prefix: ${out}`);
+    assert(!out.includes(UNDERLINE), `unexpected underline: ${out}`);
+  });
+});
+
+test("effort source: no env, no effortLevel renders auto→ prefix", () => {
+  withTmpHome((tmp) => {
+    seedSettings(tmp, {});
+    const input = JSON.stringify({
+      model: { display_name: "M" },
+      effort: { level: "xhigh" },
+    });
+    const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
+    assert(out.includes("auto→xhigh"), `expected auto→xhigh prefix: ${out}`);
+    assert(!out.includes(UNDERLINE), `unexpected underline: ${out}`);
+  });
+});
+
+test("effort source: env-locked level underlines the level", () => {
+  withTmpHome((tmp) => {
+    seedSettings(tmp, { env: { CLAUDE_CODE_EFFORT_LEVEL: "high" } });
+    const input = JSON.stringify({
+      model: { display_name: "M" },
+      effort: { level: "high" },
+    });
+    const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
+    assert(out.includes(`${UNDERLINE}high`), `expected underline+high: ${out}`);
+    assert(!out.includes("auto→"), `unexpected auto→ prefix: ${out}`);
+  });
+});
+
+test("effort source: env-locked auto underlines auto and shows resolved level", () => {
+  withTmpHome((tmp) => {
+    seedSettings(tmp, { env: { CLAUDE_CODE_EFFORT_LEVEL: "auto" } });
+    const input = JSON.stringify({
+      model: { display_name: "M" },
+      effort: { level: "xhigh" },
+    });
+    const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
+    assert(out.includes(`${UNDERLINE}auto`), `expected underline+auto: ${out}`);
+    assert(out.includes("→xhigh"), `expected →xhigh after auto: ${out}`);
   });
 });
 
@@ -421,6 +475,7 @@ const RENDER_INPUT = JSON.stringify({ model: { display_name: "T" } });
 function cleanEnv(extra) {
   const env = { ...process.env };
   delete env.CLAUDE_STATUSLINE_ICONS;
+  delete env.CLAUDE_CODE_EFFORT_LEVEL;
   return { ...env, ...extra };
 }
 

--- a/test/measure-width.js
+++ b/test/measure-width.js
@@ -33,7 +33,8 @@ worstCase.rate_limits = {
 // Call render() directly with all overrides — no subprocesses or cache files
 const lines = render(worstCase, {
   home: "/Users/username",
-  effort: "max",
+  effort: "medium",
+  effortSource: "lockedAuto",
   sandboxMode: "auto",
   now: new Date(),
   git: {


### PR DESCRIPTION

## Summary

- Read the live effort level from `data.effort.level` (statusline JSON input from Claude Code v2.1.90+) instead of inferring from settings and env. `/effort` changes now reflect immediately.
- Surface where the effort came from. Underline marks an env-locked level (`CLAUDE_CODE_EFFORT_LEVEL` set to a level). A dim `auto` prefix appears when the level was auto-resolved by Claude Code rather than set explicitly. Underlined `auto` indicates `CLAUDE_CODE_EFFORT_LEVEL=auto`.
- Align per-level colors with Claude Code's own UI palette: low=gold, medium=green, high=lavender, xhigh=violet (shares the branch color), max=bold red. Drops the previous green→red intensity ramp in favor of the categorical hues users already see in Claude Code itself.
- Drop the arrow separator between the auto prefix and the level word. Color contrast (dim auto + colored level) carries the boundary.

## Source enum

Four display states drive the rendering:

```mermaid
flowchart LR
    A["data.effort.level<br>+ settings / env"] --> B{"effortSource"}
    B -->|"explicit<br>(settings.effortLevel)"| E1["◑ medium"]
    B -->|"lockedExplicit<br>(env=high)"| E2["● <u>high</u>"]
    B -->|"auto<br>(neither set)"| E3["◑ <span style='opacity:.5'>auto</span> medium"]
    B -->|"lockedAuto<br>(env=auto)"| E4["◑ <span style='opacity:.5'><u>auto</u></span> medium"]
```

## Changes

- `lib/statusline.js` — read `data.effort.level` first; fall back to a `settings.json` cache (mtime-keyed) for env/effortLevel detection; classify the four source states; render the indicator with color-only source/level separation; swap the effort palette to gold/green/lavender/violet/bold-red and add a `lavender` (ANSI 147) constant.
- `test/cli.js` — add a stdin-effort override test plus one test per source state (four total); migrate the affected assertions to a `stripAnsi` helper so plain-text checks survive ANSI wrapping.
- `test/measure-width.js` — set the worst-case fixture to `effortSource: "lockedAuto"` with `effort: "medium"` so the longest variant (`◑ auto medium`) is exercised by the 80-column check.

## Trade-offs

- The `lockedAuto` and `lockedExplicit` cases are project-specific terminology. Claude Code's own UI surfaces only the level, not the lock source, so the underline marker is an extension rather than a mirror of upstream behavior. The colors and symbols match upstream.
- `data.effort.level` was added in Claude Code v2.1.90. On older Claude Code versions the field is absent and the existing settings/env fallback path takes over. No version gate is required because the field-presence check is implicit.
- Worst-case display width is exactly 80 columns under the new layout. Adding spaces or new glyphs would require trimming elsewhere on line 2.

## Test plan

Locally executable:

- [x] `node --test test/cli.js` — all 42 tests pass.
- [x] `node test/measure-width.js --check` — worst-case line 2 = 80 cols.
- [x] `npx eslint lib/statusline.js test/cli.js` — clean.
- [x] `npx prettier --check lib/statusline.js test/cli.js` — clean.
- [x] Per-level rendering check via inline `node -e` — each level emits the expected ANSI code.

Requires external verification:

- [x] Visual check in a real Claude Code session across the four source states (explicit / lockedExplicit / auto / lockedAuto).
- [x] Confirm `/effort low|medium|high|xhigh|max|auto` updates the indicator immediately mid-session.
