### PR TITLE
Bootstrap CLI install on first SessionStart hook run

### DIFF
--- a/hooks/sync-cli-version.js
+++ b/hooks/sync-cli-version.js
@@ -55,13 +55,6 @@ try {
 
   fs.mkdirSync(dataDir, { recursive: true });
 
-  // First run after install: /claude-code-statusline:setup already ran
-  // `npm install -g`, so the CLI is current. Just record the version and exit.
-  if (!prev) {
-    fs.writeFileSync(stored, current);
-    process.exit(0);
-  }
-
   const child = spawn(
     process.execPath,
     [__filename, INSTALL_ARG, current, stored],

--- a/test/hook.js
+++ b/test/hook.js
@@ -8,6 +8,7 @@ const os = require("os");
 const path = require("path");
 
 const HOOK = path.join(__dirname, "..", "hooks", "sync-cli-version.js");
+const PACKAGE_NAME = "@z80020100/claude-code-statusline";
 
 let failed = 0;
 
@@ -72,7 +73,14 @@ function cleanup(root) {
   fs.rmSync(root, { recursive: true, force: true });
 }
 
-test("bootstrap: first run records version and skips npm install", () => {
+function assertNpmInstalled(tree, version) {
+  assert(fs.existsSync(tree.npmLog), "npm should have been invoked");
+  const args = fs.readFileSync(tree.npmLog, "utf8").trim();
+  const expected = `install -g ${PACKAGE_NAME}@${version}`;
+  assert(args === expected, `unexpected npm args: ${args}`);
+}
+
+test("bootstrap: first run installs CLI via npm and records version", () => {
   const tree = makeTree("1.2.3");
   try {
     runHook(tree);
@@ -82,10 +90,7 @@ test("bootstrap: first run records version and skips npm install", () => {
       "utf8",
     );
     assert(stored === "1.2.3", `expected stored 1.2.3, got ${stored}`);
-    assert(
-      !fs.existsSync(tree.npmLog),
-      "npm should not run on first bootstrap",
-    );
+    assertNpmInstalled(tree, "1.2.3");
   } finally {
     cleanup(tree.root);
   }
@@ -119,12 +124,7 @@ test("mismatch: stored version differs triggers npm install of matching version"
       "utf8",
     );
     assert(stored === "1.2.3", `expected stored 1.2.3, got ${stored}`);
-    assert(fs.existsSync(tree.npmLog), "npm should have been invoked");
-    const args = fs.readFileSync(tree.npmLog, "utf8").trim();
-    assert(
-      args === "install -g @z80020100/claude-code-statusline@1.2.3",
-      `unexpected npm args: ${args}`,
-    );
+    assertNpmInstalled(tree, "1.2.3");
   } finally {
     cleanup(tree.root);
   }


### PR DESCRIPTION
## Summary

- Drop the first-run early-exit in the `SessionStart` hook. Previously the hook assumed `/claude-code-statusline:setup` had already run `npm install -g`, so on first run it just recorded the bundled `plugin.json` version and exited. With this change the empty-stored case takes the same path as a version mismatch and spawns the detached install worker, so the plugin self-bootstraps the global CLI without depending on `/setup`.
- Tighten the matching test: assert that npm is invoked with the correct `@<version>` arg on first run, and share the assertion with the existing mismatch test through a small `assertNpmInstalled(tree, version)` helper.

## Flow

```mermaid
flowchart LR
    A[SessionStart] --> B[read plugin.json<br>+ stored version]
    B --> C{current === stored?}
    C -->|yes| Z[exit 0]
    C -->|no - mismatch or empty| D[mkdir dataDir]
    D --> E[spawn detached worker<br>npm install -g pkg@current]
    E --> F[exit 0 immediately]
    E -.-> G[worker: write stored<br>on npm exit 0]
```

## Changes

- `hooks/sync-cli-version.js` — remove the `if (!prev) { fs.writeFileSync(stored, current); process.exit(0); }` branch and the surrounding comment. The single remaining short-circuit is `current === prev`, so any stored version that does not match the bundled `plugin.json` version triggers a detached worker install — including the empty-stored case on a brand-new install.
- `test/hook.js` — rename the bootstrap test from "first run records version and skips npm install" to "first run installs CLI via npm and records version" and assert the install path. Hoist the package name to a `PACKAGE_NAME` constant and extract `assertNpmInstalled(tree, version)`; reuse the helper from the existing mismatch test.

## Trade-offs

- A user who runs `/claude-code-statusline:setup` (which itself does `npm install -g`) and then starts a new Claude Code session will pay one redundant `npm install -g` for the matching version on that first session. npm treats it as a no-op but it still costs a registry round-trip. After the worker writes the stored version file the next session short-circuits at the `current === prev` check.
- A persistently failing install (offline machine and restricted prefix) means every session re-attempts. The worker is detached with `stdio: \"ignore\"` and errors are swallowed so the cost is one wasted background subprocess per session and never visible to the user.

## Test plan

Locally executable:

- [x] `node test/hook.js` — five paths pass: bootstrap (first run installs CLI), no-op (matching stored), mismatch with successful install, mismatch with failing install, missing `CLAUDE_PLUGIN_ROOT`.
- [x] `npm run check` — lint plus format plus width plus all test files. All pass.

Requires external verification:

- [x] On a fresh machine with the plugin installed but no global CLI present, start Claude Code and confirm the CLI is installed automatically within a few seconds and `~/.claude/plugin-data/claude-code-statusline/installed-version` is written without running `/claude-code-statusline:setup` first.