### PR TITLE
Add install and uninstall scripts and installation diagnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       "shfmt -i 4 -w"
     ],
     "scripts/*.sh": [
-      "shellcheck",
+      "shellcheck -x",
       "shfmt -i 4 -w"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
     "ci:local": "act push --container-architecture linux/amd64",
     "lint": "npm run lint:js && npm run lint:sh && npm run lint:yml",
     "lint:js": "eslint .",
-    "lint:sh": "shellcheck .husky/pre-commit",
+    "lint:sh": "shellcheck .husky/pre-commit scripts/*.sh",
     "lint:yml": "actionlint .github/workflows/*.yml",
     "lint:fix": "eslint --fix .",
     "format:check": "npm run format:check:js && npm run format:check:sh",
     "format:check:js": "prettier --check .",
-    "format:check:sh": "shfmt -i 4 -d .husky/pre-commit",
+    "format:check:sh": "shfmt -i 4 -d .husky/pre-commit scripts/*.sh",
     "format:fix": "npm run format:fix:js && npm run format:fix:sh",
     "format:fix:js": "prettier --write .",
-    "format:fix:sh": "shfmt -i 4 -w .husky/pre-commit",
+    "format:fix:sh": "shfmt -i 4 -w .husky/pre-commit scripts/*.sh",
     "prepare": "husky",
     "postinstall": "node -e \"console.log('\\n  Run setup to configure Claude Code automatically:\\n    claude-code-statusline setup\\n')\"",
     "prepublishOnly": "npm run test"
@@ -67,6 +67,10 @@
     "*.{json,md,yml,yaml}": "prettier --write",
     ".github/workflows/*.yml": "actionlint",
     ".husky/pre-commit": [
+      "shellcheck",
+      "shfmt -i 4 -w"
+    ],
+    "scripts/*.sh": [
       "shellcheck",
       "shfmt -i 4 -w"
     ]

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+# Shared constants and detection helpers for install/uninstall/check scripts.
+# Source from a sibling script:
+#   source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+CLAUDE_DIR="${HOME}/.claude"
+# shellcheck disable=SC2034
+CONFIG="${CLAUDE_DIR}/claude-code-statusline.json"
+PLUGIN_ID="claude-code-statusline@claude-code-statusline"
+MARKETPLACE_ID="claude-code-statusline"
+PKG_NAME="@z80020100/claude-code-statusline"
+# shellcheck disable=SC2034
+PLUGIN_DATA_DIR="${CLAUDE_DIR}/plugins/data/claude-code-statusline-claude-code-statusline"
+
+cli_present() {
+    command -v claude-code-statusline >/dev/null 2>&1
+}
+
+plugin_installed() {
+    command -v claude >/dev/null 2>&1 &&
+        claude plugin list 2>/dev/null | grep -qF "${PLUGIN_ID}"
+}
+
+marketplace_added() {
+    command -v claude >/dev/null 2>&1 &&
+        claude plugin marketplace list 2>/dev/null | grep -qF "${MARKETPLACE_ID}"
+}
+
+npm_global_installed() {
+    command -v npm >/dev/null 2>&1 &&
+        npm ls -g "${PKG_NAME}" --depth=0 >/dev/null 2>&1
+}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -57,9 +57,9 @@ if [[ "${PLUGIN_PRESENT}" == "yes" ]]; then
     [[ -n "${PLUGIN_VERSION}" ]] && echo "  Version: ${PLUGIN_VERSION}"
 fi
 if [[ -f "${STORED_VERSION}" ]]; then
-    echo "  Stored installed-version: $(cat "${STORED_VERSION}")"
+    echo "  Plugin-installed CLI version: $(cat "${STORED_VERSION}")"
 else
-    echo "  Stored installed-version: (not present)"
+    echo "  Plugin-installed CLI version: (not present)"
 fi
 if marketplace_added; then
     echo "  Marketplace: registered"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+STORED_VERSION="${PLUGIN_DATA_DIR}/installed-version"
+SETTINGS="${CLAUDE_DIR}/settings.json"
+
+read_json_field() {
+    node -e '
+        try {
+            const v = require(process.argv[1])[process.argv[2]];
+            if (v !== undefined && v !== null) {
+                console.log(typeof v === "string" ? v : JSON.stringify(v));
+            }
+        } catch {}
+    ' "$1" "$2"
+}
+
+npm_global_version() {
+    npm ls -g "${PKG_NAME}" --depth=0 2>/dev/null |
+        awk -v pkg="${PKG_NAME}" '
+            index($0, pkg "@") { n = split($0, a, "@"); print a[n] }
+        '
+}
+
+PLUGIN_PRESENT=no
+NPM_PRESENT=no
+plugin_installed && PLUGIN_PRESENT=yes
+npm_global_installed && NPM_PRESENT=yes
+
+case "${PLUGIN_PRESENT}/${NPM_PRESENT}" in
+yes/*) INSTALL_TYPE="plugin" ;;
+no/yes) INSTALL_TYPE="standalone npm" ;;
+no/no) INSTALL_TYPE="not installed" ;;
+esac
+
+echo "Installation type: ${INSTALL_TYPE}"
+echo
+echo "[Plugin]"
+echo "  Installed: ${PLUGIN_PRESENT}"
+if [[ -f "${STORED_VERSION}" ]]; then
+    echo "  Stored installed-version: $(cat "${STORED_VERSION}")"
+else
+    echo "  Stored installed-version: (not present)"
+fi
+if marketplace_added; then
+    echo "  Marketplace: registered"
+else
+    echo "  Marketplace: not registered"
+fi
+echo
+echo "[npm global (-g)]"
+echo "  Installed: ${NPM_PRESENT}"
+if [[ "${NPM_PRESENT}" == "yes" ]]; then
+    NPM_VERSION="$(npm_global_version)"
+    [[ -n "${NPM_VERSION}" ]] && echo "  Version: ${NPM_VERSION}"
+fi
+echo
+echo "[CLI on PATH]"
+if cli_present; then
+    echo "  Path: $(command -v claude-code-statusline)"
+    echo "  Version: $(claude-code-statusline --version)"
+else
+    echo "  (not on PATH)"
+fi
+echo
+echo "[Claude Code settings] ${SETTINGS}"
+STATUSLINE="$(read_json_field "${SETTINGS}" "statusLine")"
+if [[ -n "${STATUSLINE}" ]]; then
+    echo "  statusLine: ${STATUSLINE}"
+else
+    echo "  statusLine: (not configured)"
+fi
+echo
+echo "[User config] ${CONFIG}"
+if [[ -f "${CONFIG}" ]]; then
+    sed 's/^/  /' "${CONFIG}"
+else
+    echo "  (absent)"
+fi

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -18,6 +18,18 @@ read_json_field() {
     ' "$1" "$2"
 }
 
+plugin_version() {
+    claude plugin list 2>/dev/null |
+        awk -v id="${PLUGIN_ID}" '
+            $NF == id { found = 1; next }
+            found && /Version:/ {
+                sub(/.*Version:[[:space:]]*/, "")
+                print
+                exit
+            }
+        '
+}
+
 npm_global_version() {
     npm ls -g "${PKG_NAME}" --depth=0 2>/dev/null |
         awk -v pkg="${PKG_NAME}" '
@@ -40,6 +52,10 @@ echo "Installation type: ${INSTALL_TYPE}"
 echo
 echo "[Plugin]"
 echo "  Installed: ${PLUGIN_PRESENT}"
+if [[ "${PLUGIN_PRESENT}" == "yes" ]]; then
+    PLUGIN_VERSION="$(plugin_version)"
+    [[ -n "${PLUGIN_VERSION}" ]] && echo "  Version: ${PLUGIN_VERSION}"
+fi
 if [[ -f "${STORED_VERSION}" ]]; then
     echo "  Stored installed-version: $(cat "${STORED_VERSION}")"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_SLUG="z80020100/claude-code-statusline"
+REPO_GIT_URL="https://github.com/${REPO_SLUG}.git"
+
+usage() {
+    cat <<EOF >&2
+Usage: $0 [local|dev|stable|custom <ref>]
+  local           install from ${REPO_ROOT} (default when prompted)
+  dev             install from ${REPO_SLUG} (main branch)
+  stable          install from ${REPO_SLUG} (latest GitHub release)
+  custom <ref>    install from ${REPO_GIT_URL}#<ref> (branch, tag, or SHA)
+EOF
+}
+
+latest_release_tag() {
+    curl -fsSL "https://api.github.com/repos/${REPO_SLUG}/releases/latest" |
+        sed -nE 's/.*"tag_name": *"([^"]+)".*/\1/p' |
+        head -1
+}
+
+prompt_ref() {
+    echo "Fetching refs from ${REPO_GIT_URL}..." >&2
+    local heads=() tags=() ref name pick i=1
+    while IFS=$'\t' read -r _ ref; do
+        case "${ref}" in
+        refs/heads/*) heads+=("${ref#refs/heads/}") ;;
+        refs/tags/*) tags+=("${ref#refs/tags/}") ;;
+        esac
+    done < <(git ls-remote --heads --tags --refs "${REPO_GIT_URL}")
+
+    local all=()
+    ((${#heads[@]} > 0)) && all+=("${heads[@]}")
+    ((${#tags[@]} > 0)) && all+=("${tags[@]}")
+
+    if ((${#heads[@]} > 0)); then
+        echo "Branches:" >&2
+        for name in "${heads[@]}"; do
+            printf "  %2d) %s\n" "${i}" "${name}" >&2
+            i=$((i + 1))
+        done
+    fi
+    if ((${#tags[@]} > 0)); then
+        echo "Tags:" >&2
+        for name in "${tags[@]}"; do
+            printf "  %2d) %s\n" "${i}" "${name}" >&2
+            i=$((i + 1))
+        done
+    fi
+
+    read -r -p "Select number or type ref: " pick
+    if [[ -z "${pick}" ]]; then
+        echo "No selection provided" >&2
+        exit 1
+    fi
+    if [[ "${pick}" =~ ^[0-9]+$ ]] && ((pick >= 1 && pick <= ${#all[@]})); then
+        printf '%s' "${all[$((pick - 1))]}"
+    else
+        printf '%s' "${pick}"
+    fi
+}
+
+SOURCE="${1:-}"
+REF="${2:-}"
+
+if [[ -z "${SOURCE}" ]]; then
+    echo "Choose installation source:"
+    echo "  1) local    ${REPO_ROOT}"
+    echo "  2) dev      ${REPO_SLUG} (main branch)"
+    echo "  3) stable   ${REPO_SLUG} (latest GitHub release)"
+    echo "  4) custom   specific branch, tag, or SHA on ${REPO_SLUG}"
+    read -r -p "Enter [1/2/3/4]: " CHOICE
+    case "${CHOICE}" in
+    1) SOURCE="local" ;;
+    2) SOURCE="dev" ;;
+    3) SOURCE="stable" ;;
+    4)
+        SOURCE="custom"
+        REF="$(prompt_ref)"
+        ;;
+    *)
+        echo "Invalid choice: ${CHOICE}" >&2
+        exit 1
+        ;;
+    esac
+fi
+
+case "${SOURCE}" in
+local)
+    MARKETPLACE_PATH="${REPO_ROOT}"
+    ;;
+dev)
+    MARKETPLACE_PATH="${REPO_GIT_URL}#main"
+    ;;
+stable)
+    echo "==> Fetching latest release tag from ${REPO_SLUG}"
+    REF="$(latest_release_tag)"
+    if [[ -z "${REF}" ]]; then
+        echo "No release tag found on ${REPO_SLUG}" >&2
+        exit 1
+    fi
+    echo "==> Resolved release: ${REF}"
+    MARKETPLACE_PATH="${REPO_GIT_URL}#${REF}"
+    ;;
+custom)
+    if [[ -z "${REF}" ]]; then
+        echo "Branch / tag / SHA required" >&2
+        usage
+        exit 1
+    fi
+    MARKETPLACE_PATH="${REPO_GIT_URL}#${REF}"
+    ;;
+*)
+    usage
+    exit 1
+    ;;
+esac
+
+echo "==> Adding marketplace: ${MARKETPLACE_PATH}"
+claude plugin marketplace add "${MARKETPLACE_PATH}"
+
+echo "==> Installing plugin: ${PLUGIN_ID}"
+claude plugin install "${PLUGIN_ID}"
+
+echo "==> Done."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+CACHE_DIR="${CLAUDE_DIR}/.cache"
+
+local_files_present() {
+    [[ -f "${CONFIG}" ]] ||
+        [[ -f "${CACHE_DIR}/update-check-claude.json" ]] ||
+        [[ -f "${CACHE_DIR}/update-check-statusline.json" ]] ||
+        [[ -d "${PLUGIN_DATA_DIR}" ]]
+}
+
+remove_file() {
+    if [[ -f "$1" ]]; then
+        echo "==> Removing $1"
+        rm -f "$1"
+    fi
+}
+
+remove_dir() {
+    if [[ -d "$1" ]]; then
+        echo "==> Removing $1"
+        rm -rf "$1"
+    fi
+}
+
+if ! cli_present && ! plugin_installed && ! marketplace_added && ! npm_global_installed && ! local_files_present; then
+    echo "Nothing to uninstall."
+    exit 0
+fi
+
+if cli_present; then
+    echo "==> Clearing statusline configuration via CLI"
+    claude-code-statusline setup --uninstall
+fi
+
+remove_file "${CONFIG}"
+remove_file "${CACHE_DIR}/update-check-claude.json"
+remove_file "${CACHE_DIR}/update-check-statusline.json"
+remove_dir "${PLUGIN_DATA_DIR}"
+
+if plugin_installed; then
+    echo "==> Uninstalling Claude Code plugin (${PLUGIN_ID})"
+    claude plugin uninstall "${PLUGIN_ID}"
+fi
+
+if marketplace_added; then
+    echo "==> Removing marketplace entry (${MARKETPLACE_ID})"
+    claude plugin marketplace remove "${MARKETPLACE_ID}"
+fi
+
+if npm_global_installed; then
+    echo "==> Uninstalling global npm package (${PKG_NAME})"
+    npm uninstall -g "${PKG_NAME}"
+fi
+
+echo "==> Done."


### PR DESCRIPTION

## Summary

- Add three shell scripts under `scripts/` covering the plugin's full local lifecycle: `install.sh` picks a marketplace source and runs `claude plugin install`; `uninstall.sh` detects each component and removes only what is present; `check.sh` reports installation state across plugin / marketplace / npm-global / CLI / settings / user config.
- Extract `scripts/_common.sh` with shared constants (`PLUGIN_ID`, `MARKETPLACE_ID`, `PKG_NAME`, `CONFIG`, `PLUGIN_DATA_DIR`) and detection helpers (`cli_present`, `plugin_installed`, `marketplace_added`, `npm_global_installed`) so the three entry-point scripts have a single source of truth.
- Cleanup now removes `~/.claude/plugins/data/claude-code-statusline-claude-code-statusline/`. `claude plugin uninstall` does not touch that directory and the `installed-version` file inside is what gates the SessionStart hook's auto-bootstrap. Without this cleanup the next install would silently skip the npm bootstrap because `current === prev` short-circuits in `hooks/sync-cli-version.js`.
- Extend `lint:sh` plus `format:check:sh` plus `format:fix:sh` and the `lint-staged` map in `package.json` to cover `scripts/*.sh` so the new files run through `shellcheck` and `shfmt -i 4` alongside `.husky/pre-commit`.

## Flow

```mermaid
flowchart LR
    A[scripts/install.sh] -->|local / dev / stable / custom| B[claude plugin marketplace add]
    B --> C[claude plugin install]
    C --> D[next SessionStart]
    D --> E[hooks/sync-cli-version.js]
    E -->|stored !== plugin.json version| F[detached npm install -g pkg@version]
    F --> G[write installed-version]

    H[scripts/uninstall.sh] -->|cli_present| I[claude-code-statusline setup --uninstall]
    H --> J[remove CONFIG / cache / PLUGIN_DATA_DIR]
    H -->|plugin_installed| K[claude plugin uninstall]
    H -->|marketplace_added| L[claude plugin marketplace remove]
    H -->|npm_global_installed| M[npm uninstall -g]

    N[scripts/check.sh] --> O[probe plugin + marketplace + npm + CLI]
    N --> P[render report with stored installed-version + statusLine + user config]
```

## Changes

- `scripts/_common.sh` — shared constants and detection helpers. Sourced by the other three scripts via `source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"` so each script self-locates the lib regardless of the caller's working directory. Carries `# shellcheck shell=bash` plus `disable=SC2034` markers on the constants that are only consumed from sourcing scripts.
- `scripts/install.sh` — interactive or argument-driven installer. Four sources: `local` from `${REPO_ROOT}`, `dev` from `${REPO_GIT_URL}#main`, `stable` from the latest GitHub release tag (parsed out of the `releases/latest` API response), `custom <ref>` from any branch / tag / SHA with `prompt_ref` listing remote refs via `git ls-remote` when invoked interactively. Empty input on the ref prompt aborts immediately. `curl` runs with `-fsSL` so failures still print to stderr without a misleading `|| true` swallow. Each step prints a `==>` marker and the final line is `==> Done.`.
- `scripts/uninstall.sh` — detection-first cleanup. Probes CLI / plugin / marketplace / npm-global / local-files; if every probe is negative the script prints `Nothing to uninstall.` and exits 0. Otherwise it removes only the components that are present and labels each removal with a `==>` marker. The probes use the helpers from `_common.sh` so genuine failures still surface under `set -euo pipefail` rather than being swallowed by `|| true`.
- `scripts/check.sh` — diagnostic report covering install type (`plugin` / `standalone npm` / `not installed`), plugin status with stored `installed-version`, marketplace registration, npm global presence and version, CLI path on `PATH`, the `statusLine` field in `~/.claude/settings.json`, and the user config file contents. `read_json_field` passes the file path and field name through `process.argv` instead of interpolating into the `node -e` source so unusual paths cannot break the JS literal.
- `package.json` — `lint:sh` / `format:check:sh` / `format:fix:sh` and the `lint-staged` map all gain `scripts/*.sh` so the new files run through `shellcheck` plus `shfmt -i 4` on every staged commit.

## Trade-offs

- The three scripts duplicate the existing detection logic that lives in `lib/setup.js` and `hooks/sync-cli-version.js`. Re-implementing the checks in bash keeps the entry-point scripts standalone — they work before `npm install` has happened and without booting Node — at the cost of a parallel implementation that has to track the same plugin / marketplace / data-dir naming conventions.
- `uninstall.sh` removes `~/.claude/plugins/data/claude-code-statusline-claude-code-statusline/` even if a user has manually placed unrelated files there. The directory is owned by this plugin's hook so this is the expected lifecycle, but a custom-tooling user who repurposed the path will lose those files.
- `install.sh` for the `stable` source parses the GitHub API response with a single `sed -nE` regex for `tag_name` instead of a JSON parser so the script can run without `jq`. A future API change to the response shape would silently fall through to the `No release tag found` branch.

## Test plan

Locally executable:

- [x] `npm run lint:sh` — `shellcheck` passes for `.husky/pre-commit` plus `scripts/*.sh`.
- [x] `npm run format:check:sh` — `shfmt -i 4 -d` reports no diff.
- [x] `bash -n` syntax check passes on `_common.sh` plus `install.sh` plus `uninstall.sh` plus `check.sh`.

Requires external verification:

- [x] On a host with no statusline component installed: `bash scripts/uninstall.sh` prints `Nothing to uninstall.` and exits 0.
- [x] After `bash scripts/install.sh dev` plus a new Claude Code session: `~/.claude/plugins/data/claude-code-statusline-claude-code-statusline/installed-version` is written and `claude-code-statusline --version` matches the bundled `plugin.json` version.
- [x] After `bash scripts/install.sh stable`: the resolved release tag is reported and the install matches the latest GitHub release.
- [x] `bash scripts/uninstall.sh` followed by `bash scripts/check.sh` reports `Plugin-installed CLI version: (not present)` plus `Installation type: not installed` (regression guard for the `installed-version` cleanup that unblocks the next install's bootstrap).

