### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-statusline",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "author": {
     "name": "Cliff Wu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@z80020100/claude-code-statusline",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "main": "lib/statusline.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump package version from 1.1.0 to 1.2.0

## Highlights since v1.1.0
- Add target-aware update-check module with CLI subcommand and plugin slash command, surfacing Claude Code and statusline self-update indicators on the version banner
- Add SessionStart hook that syncs the CLI to the bundled plugin version and bootstraps the install on first run
- Add install and uninstall scripts plus an installation diagnostic, and extend the shell lint and format pipeline to the scripts directory
- Restructure READMEs into User Guide and Developer Guide sections and align terminology to "usage limit"
- Bump .nvmrc to Node 20.20

## Test plan
- [x] \`npm run check\` passes (lint + format + tests)