### PR TITLE
Detect worktree from workspace.git_worktree instead of git rev-parse

### DIFF
--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -254,7 +254,7 @@ function render(data, options = {}) {
   const dirPath = projectDir ? tildify(projectDir) : "";
   const cwdPath = cwd && cwd !== projectDir ? tildify(cwd) : "";
 
-  // ── Git branch + dirty + worktree + diff vs main (cached) ──
+  // ── Git branch + dirty + diff vs main (cached) + worktree (from JSON) ──
   let branch = "";
   let dirty = "";
   let isWorktree = false;
@@ -268,79 +268,68 @@ function render(data, options = {}) {
       diffAdded = 0,
       diffRemoved = 0,
     } = options.git);
-  } else if (cwd) {
-    const cacheFile = tmpCacheFile("git");
-    const cacheMaxAge = 5000;
-    let useCache = false;
-    try {
-      const stat = fs.statSync(cacheFile);
-      const cached = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
-      if (cached.cwd === cwd && Date.now() - stat.mtimeMs < cacheMaxAge) {
-        branch = cached.branch;
-        dirty = cached.dirty;
-        isWorktree = cached.isWorktree ?? false;
-        diffAdded = cached.diffAdded ?? 0;
-        diffRemoved = cached.diffRemoved ?? 0;
-        useCache = true;
-      }
-    } catch {}
-    if (!useCache) {
+  } else {
+    // Trust Claude Code's workspace.git_worktree: populated for any linked
+    // worktree, absent in the main working tree.
+    isWorktree = !!data.workspace?.git_worktree;
+    if (cwd) {
+      const cacheFile = tmpCacheFile("git");
+      const cacheMaxAge = 5000;
+      let useCache = false;
       try {
-        const statusOut = execSync("git status --short --branch", {
-          cwd,
-          timeout: 2000,
-          encoding: "utf8",
-          stdio: ["pipe", "pipe", "ignore"],
-        }).trim();
-        const lines = statusOut.split("\n");
-        // First line: "## branch...tracking" or "## HEAD (no branch)"
-        const branchMatch = lines[0].match(/^## (\S+?)(?:\.\.\.|$)/);
-        branch = branchMatch ? branchMatch[1] : "";
-        // Remaining lines = changed files
-        dirty = lines.length > 1 ? "*" : "";
-        // Detect git worktree: git-dir differs from git-common-dir
-        try {
-          const revOut = execSync(
-            "git rev-parse --path-format=absolute --git-dir --git-common-dir",
-            {
-              cwd,
-              timeout: 1000,
-              encoding: "utf8",
-              stdio: ["pipe", "pipe", "ignore"],
-            },
-          ).trim();
-          const [gitDir, commonDir] = revOut.split("\n");
-          isWorktree = gitDir !== commonDir;
-        } catch {}
-        // Diff stats relative to main (or master) branch
-        for (const base of ["main", "master"]) {
-          try {
-            const diffOut = execSync(`git diff ${base} --shortstat`, {
-              cwd,
-              timeout: 2000,
-              encoding: "utf8",
-              stdio: ["pipe", "pipe", "ignore"],
-            }).trim();
-            const insMatch = diffOut.match(/(\d+) insertion/);
-            const delMatch = diffOut.match(/(\d+) deletion/);
-            if (insMatch) diffAdded = Number(insMatch[1]);
-            if (delMatch) diffRemoved = Number(delMatch[1]);
-            break;
-          } catch {}
+        const stat = fs.statSync(cacheFile);
+        const cached = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+        if (cached.cwd === cwd && Date.now() - stat.mtimeMs < cacheMaxAge) {
+          branch = cached.branch;
+          dirty = cached.dirty;
+          diffAdded = cached.diffAdded ?? 0;
+          diffRemoved = cached.diffRemoved ?? 0;
+          useCache = true;
         }
-        fs.writeFileSync(
-          cacheFile,
-          JSON.stringify({
-            cwd,
-            branch,
-            dirty,
-            isWorktree,
-            diffAdded,
-            diffRemoved,
-          }),
-          "utf8",
-        );
       } catch {}
+      if (!useCache) {
+        try {
+          const statusOut = execSync("git status --short --branch", {
+            cwd,
+            timeout: 2000,
+            encoding: "utf8",
+            stdio: ["pipe", "pipe", "ignore"],
+          }).trim();
+          const lines = statusOut.split("\n");
+          // First line: "## branch...tracking" or "## HEAD (no branch)"
+          const branchMatch = lines[0].match(/^## (\S+?)(?:\.\.\.|$)/);
+          branch = branchMatch ? branchMatch[1] : "";
+          // Remaining lines = changed files
+          dirty = lines.length > 1 ? "*" : "";
+          // Diff stats relative to main (or master) branch
+          for (const base of ["main", "master"]) {
+            try {
+              const diffOut = execSync(`git diff ${base} --shortstat`, {
+                cwd,
+                timeout: 2000,
+                encoding: "utf8",
+                stdio: ["pipe", "pipe", "ignore"],
+              }).trim();
+              const insMatch = diffOut.match(/(\d+) insertion/);
+              const delMatch = diffOut.match(/(\d+) deletion/);
+              if (insMatch) diffAdded = Number(insMatch[1]);
+              if (delMatch) diffRemoved = Number(delMatch[1]);
+              break;
+            } catch {}
+          }
+          fs.writeFileSync(
+            cacheFile,
+            JSON.stringify({
+              cwd,
+              branch,
+              dirty,
+              diffAdded,
+              diffRemoved,
+            }),
+            "utf8",
+          );
+        } catch {}
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Replace the self-detected worktree check (`git rev-parse --path-format=absolute --git-dir --git-common-dir`) with the official `data.workspace.git_worktree` field that Claude Code now ships in the JSON it pipes to the status line. The field is populated for any linked git worktree and absent in the main working tree.
- One subprocess per render is removed from the cache-miss path. `isWorktree` is now derived live from JSON on every render rather than cached for 5 seconds with the rest of the git block, so a fresh worktree change reflects immediately.
- `lib/statusline.js` drops `isWorktree` from the git cache schema. Old caches that still carry the key are silently ignored on read because the field is no longer destructured. The `options.git` test-injection contract is preserved so `test/measure-width.js` and other callers can keep driving the worktree icon directly.

## Test plan

Locally executable:

- [x] `npm run check` — lint plus format plus width check plus all unit tests.
- [x] Smoke render `data.workspace.git_worktree` set / absent / empty — worktree icon `⊞` shows only on the truthy non-empty case.
- [x] Real worktree end-to-end — install the branch globally, `git worktree add` a sibling tree, and confirm the icon appears in the live status line inside the worktree only.

Requires external verification:

- [x] CI on push passes on GitHub Actions.