### PR TITLE
Show branch indicator for detached HEAD and empty and no-git states

### DIFF
--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -45,7 +45,7 @@ const ICON_SETS = {
  * Render Claude Code status line.
  * @param {object} data - JSON data from Claude Code stdin
  * @param {object} [options] - Overrides for testability and cross-platform
- * @param {object} [options.git] - { branch, dirty, isWorktree, diffAdded, diffRemoved }
+ * @param {object} [options.git] - { branch, branchState, dirty, isWorktree, diffAdded, diffRemoved }
  * @param {string} [options.effort] - Effort level override
  * @param {string} [options.effortSource] - "auto" | "explicit" | "lockedAuto" | "lockedExplicit"
  * @param {string} [options.sandboxMode] - Sandbox mode override ("", "auto", "on")
@@ -255,7 +255,9 @@ function render(data, options = {}) {
   const cwdPath = cwd && cwd !== projectDir ? tildify(cwd) : "";
 
   // ── Git branch + dirty + diff vs main (cached) + worktree (from JSON) ──
+  // branchState drives branch-line color (e.g. "detached" → coral warning).
   let branch = "";
+  let branchState = "";
   let dirty = "";
   let isWorktree = false;
   let diffAdded = 0;
@@ -263,6 +265,7 @@ function render(data, options = {}) {
   if (options.git) {
     ({
       branch = "",
+      branchState = "",
       dirty = "",
       isWorktree = false,
       diffAdded = 0,
@@ -281,6 +284,7 @@ function render(data, options = {}) {
         const cached = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
         if (cached.cwd === cwd && Date.now() - stat.mtimeMs < cacheMaxAge) {
           branch = cached.branch;
+          branchState = cached.branchState ?? "";
           dirty = cached.dirty;
           diffAdded = cached.diffAdded ?? 0;
           diffRemoved = cached.diffRemoved ?? 0;
@@ -296,9 +300,28 @@ function render(data, options = {}) {
             stdio: ["pipe", "pipe", "ignore"],
           }).trim();
           const lines = statusOut.split("\n");
-          // First line: "## branch...tracking" or "## HEAD (no branch)"
-          const branchMatch = lines[0].match(/^## (\S+?)(?:\.\.\.|$)/);
-          branch = branchMatch ? branchMatch[1] : "";
+          // First line variants:
+          //   "## main...origin/main"     — normal branch
+          //   "## HEAD (no branch)"       — detached HEAD (checkout, rebase, bisect)
+          const firstLine = lines[0];
+          if (firstLine.startsWith("## HEAD (no branch)")) {
+            branchState = "detached";
+            try {
+              const shortHash = execSync("git rev-parse --short HEAD", {
+                cwd,
+                timeout: 2000,
+                encoding: "utf8",
+                stdio: ["pipe", "pipe", "ignore"],
+              }).trim();
+              branch = `(detached) ${shortHash}`;
+            } catch {
+              branch = "(detached)";
+            }
+          } else {
+            const branchMatch = firstLine.match(/^## (\S+?)(?:\.\.\.|$)/);
+            branch = branchMatch ? branchMatch[1] : "";
+            branchState = branch ? "normal" : "";
+          }
           // Remaining lines = changed files
           dirty = lines.length > 1 ? "*" : "";
           // Diff stats relative to main (or master) branch
@@ -322,6 +345,7 @@ function render(data, options = {}) {
             JSON.stringify({
               cwd,
               branch,
+              branchState,
               dirty,
               diffAdded,
               diffRemoved,
@@ -568,8 +592,10 @@ function render(data, options = {}) {
         ? ` ${green}+${diffAdded}${reset} ${red}-${diffRemoved}${reset}`
         : "";
     const wtStr = isWorktree ? ` ${teal}${icons.tree}${reset}` : "";
+    // Detached HEAD uses coral as a warning that new commits will be orphaned.
+    const branchColor = branchState === "detached" ? coral : violet;
     workspaceParts.push(
-      `${violet}${icons.gitBranch} ${branch}${dirtyStr}${wtStr}${diffStr}${reset}`,
+      `${branchColor}${icons.gitBranch} ${branch}${dirtyStr}${wtStr}${diffStr}${reset}`,
     );
   }
   // Compress leading path in a parts array when line exceeds maxCols

--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -357,7 +357,41 @@ function render(data, options = {}) {
             }),
             "utf8",
           );
-        } catch {}
+        } catch {
+          // git status failed — distinguish "not a repo" from transient errors
+          // by walking up for a `.git` entry. Only cache the no-repo verdict so
+          // transient failures (timeout, etc.) retry on the next render.
+          let dir = cwd;
+          let isRepo = false;
+          while (true) {
+            try {
+              fs.statSync(path.join(dir, ".git"));
+              isRepo = true;
+              break;
+            } catch {}
+            const parent = path.dirname(dir);
+            if (parent === dir) break;
+            dir = parent;
+          }
+          if (!isRepo) {
+            branch = "(not a repo)";
+            branchState = "norepo";
+            try {
+              fs.writeFileSync(
+                cacheFile,
+                JSON.stringify({
+                  cwd,
+                  branch,
+                  branchState,
+                  dirty,
+                  diffAdded,
+                  diffRemoved,
+                }),
+                "utf8",
+              );
+            } catch {}
+          }
+        }
       }
     }
   }
@@ -597,8 +631,11 @@ function render(data, options = {}) {
         ? ` ${green}+${diffAdded}${reset} ${red}-${diffRemoved}${reset}`
         : "";
     const wtStr = isWorktree ? ` ${teal}${icons.tree}${reset}` : "";
-    // Detached HEAD uses coral as a warning that new commits will be orphaned.
-    const branchColor = branchState === "detached" ? coral : violet;
+    // Detached HEAD uses coral as a warning that new commits will be orphaned;
+    // norepo uses dim to mute the line for non-git directories.
+    let branchColor = violet;
+    if (branchState === "detached") branchColor = coral;
+    else if (branchState === "norepo") branchColor = dim;
     workspaceParts.push(
       `${branchColor}${icons.gitBranch} ${branch}${dirtyStr}${wtStr}${diffStr}${reset}`,
     );

--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -303,7 +303,9 @@ function render(data, options = {}) {
           // First line variants:
           //   "## main...origin/main"     — normal branch
           //   "## HEAD (no branch)"       — detached HEAD (checkout, rebase, bisect)
+          //   "## No commits yet on main" — empty repo before first commit
           const firstLine = lines[0];
+          const emptyMatch = firstLine.match(/^## No commits yet on (\S+)/);
           if (firstLine.startsWith("## HEAD (no branch)")) {
             branchState = "detached";
             try {
@@ -317,6 +319,9 @@ function render(data, options = {}) {
             } catch {
               branch = "(detached)";
             }
+          } else if (emptyMatch) {
+            branchState = "empty";
+            branch = `${emptyMatch[1]} (empty)`;
           } else {
             const branchMatch = firstLine.match(/^## (\S+?)(?:\.\.\.|$)/);
             branch = branchMatch ? branchMatch[1] : "";


### PR DESCRIPTION
## Summary
- Render `(detached) <short-hash>` in coral when HEAD is detached so the warning is immediately visible.
- Render `<default-branch> (empty)` in violet for repositories with no commits yet so the default branch is still surfaced.
- Render `(not a repo)` in dim when the cwd has no `.git` ancestor so non-git directories no longer collapse the workspace line.

Closes #30.

## Test plan
- [x] `npm run lint:js`
- [x] `npm test` (92 tests)
- [x] Manual: real detached HEAD repo renders `⎇ (detached) <hash>` in coral.
- [x] Manual: freshly `git init`ed empty repo renders `⎇ main (empty)` in violet.
- [x] Manual: non-git directory renders `⎇ (not a repo)` in dim.
- [x] Manual: subdirectory of a normal repo still resolves to its branch (parent `.git` walk does not falsely trigger no-repo).