### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-statusline",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "author": {
     "name": "Cliff Wu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@z80020100/claude-code-statusline",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "main": "lib/statusline.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump package version from 1.2.0 to 1.2.1

## Highlights since v1.2.0
- Detect worktree natively from `workspace.git_worktree` instead of shelling out to `git rev-parse`
- Show non-branch git states: detached HEAD short hash in coral, empty default-branch marker for fresh repos, and a dim "not a repo" marker outside git

## Test plan
- [x] `npm run check` passes (lint + format + tests)