### PR TITLE
Document plugin auto-update toggle and post-update reload step

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -139,6 +139,11 @@ claude-code-statusline update-check statusline off   # statusline セルフチ�
 - **Claude Code プラグイン** — `claude plugin update claude-code-statusline@claude-code-statusline` を実行し、Claude Code を再起動してください。
 - **npm** — `npm install -g @z80020100/claude-code-statusline@latest`。
 
+#### 自動更新（プラグイン経由のみ）
+
+1. `/plugin` を実行 → **Marketplaces** タブ → `claude-code-statusline` を選択 → **Enable auto-update** を選びます。
+2. プラグインが更新された後は `/clear` を実行するか Claude Code を再起動すると対応バージョンの CLI がインストールされます。
+
 ### 表示レイアウト
 
 全フィールドを最大幅で表示した場合：

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ When the indicator surfaces a newer release, upgrade through the path you used t
 - **Claude Code plugin** — `claude plugin update claude-code-statusline@claude-code-statusline` and restart Claude Code.
 - **npm** — `npm install -g @z80020100/claude-code-statusline@latest`.
 
+#### Auto-update (plugin only)
+
+1. Run `/plugin` → **Marketplaces** tab → select `claude-code-statusline` → choose **Enable auto-update**.
+2. After Claude Code updates the plugin, run `/clear` or restart Claude Code to install the matching CLI version.
+
 ### Display Layout
 
 All fields at maximum width:

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -139,6 +139,11 @@ claude-code-statusline update-check statusline off   # 停用 statusline 自我�
 - **Claude Code plugin** — `claude plugin update claude-code-statusline@claude-code-statusline` 並重新啟動 Claude Code。
 - **npm** — `npm install -g @z80020100/claude-code-statusline@latest`。
 
+#### 自動更新（僅限 plugin 安裝方式）
+
+1. 執行 `/plugin` → **Marketplaces** 分頁 → 選 `claude-code-statusline` → 選 **Enable auto-update**。
+2. Claude Code 自動更新 plugin 後須執行 `/clear` 或重啟 Claude Code 才會安裝對應版本的 CLI。
+
 ### 顯示佈局
 
 所有欄位最大寬度的呈現：


### PR DESCRIPTION
## Summary

- Add an `Auto-update (plugin only)` subsection under `Update Check` in all three READMEs (English, Japanese, Traditional Chinese) so plugin users know they can let Claude Code keep the marketplace plugin current instead of upgrading by hand.
- Document the two-step toggle — `/plugin` → **Marketplaces** tab → select `claude-code-statusline` → **Enable auto-update** — so the path matches the actual Claude Code UI.
- Call out the post-update reload requirement — after the plugin updates run `/clear` or restart Claude Code — so the matching CLI version is actually installed by the SessionStart hook.

## Test plan

Locally executable:

- [x] `npx prettier --check README.md README.ja.md README.zh-TW.md` passes.
- [x] Heading symmetry across all three READMEs — every `##`, `###`, and `####` line number matches across the files (verified via `grep -n "^## \|^### \|^#### " README*.md`).

Requires external verification:

- [ ] Rendered preview on GitHub shows the new subsection in correct heading hierarchy across all three READMEs.