### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@z80020100/claude-code-statusline",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "main": "lib/statusline.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump package version from 1.2.1 to 1.3.0

## Highlights since v1.2.1
- Add a Claude Code component status module that runs a cached background check against the service health endpoint
- Show a service health lamp in the version banner driven by the cached component status

## Test plan
- [x] `npm run check` passes (lint + format + tests)