### PR TITLE
Add version consistency test and sync plugin.json to 1.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-statusline",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "author": {
     "name": "Cliff Wu",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "check": "npm run lint && npm run format:check && npm run test",
     "fix": "npm run lint:fix && npm run format:fix",
-    "test": "node test/measure-width.js --check && node test/config.js && node test/update-check.js && node test/claude-status.js && node test/hook.js && node test/cli.js",
+    "test": "node test/measure-width.js --check && node test/config.js && node test/update-check.js && node test/claude-status.js && node test/hook.js && node test/cli.js && node test/version.js",
     "simulate": "node test/measure-width.js",
     "ci:local": "act push --container-architecture linux/amd64",
     "lint": "npm run lint:js && npm run lint:sh && npm run lint:yml",

--- a/test/version.js
+++ b/test/version.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`\x1b[38;5;114m\u2713\x1b[0m ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`\x1b[38;5;167m\u2717\x1b[0m ${name}`);
+    console.log(`  ${err.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function readVersion(rel) {
+  const file = path.join(__dirname, "..", rel);
+  return JSON.parse(fs.readFileSync(file, "utf8")).version;
+}
+
+// ── version consistency ──────────────────────────────
+
+test("package.json and .claude-plugin/plugin.json declare the same version", () => {
+  const pkg = readVersion("package.json");
+  const plugin = readVersion(".claude-plugin/plugin.json");
+  assert(pkg, "package.json declares no version");
+  assert(
+    pkg === plugin,
+    `version mismatch: package.json=${pkg} plugin.json=${plugin}`,
+  );
+});
+
+// ── summary ──────────────────────────────────────────
+
+console.log();
+if (failed) {
+  console.log(`\x1b[38;5;167m${failed} test(s) failed.\x1b[0m`);
+} else {
+  console.log(`\x1b[38;5;114mAll tests passed.\x1b[0m`);
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

- The v1.3.0 release bumped `package.json` to 1.3.0 but left `.claude-plugin/plugin.json` at 1.2.1, so the Claude Code plugin-marketplace install path reported a stale version against 1.3.0 code. `plugin.json` is not in `package.json` `files`, so npm packages were unaffected — only the marketplace manifest drifted.
- Sync `plugin.json` to 1.3.0 and add a test asserting the two manifests always declare the same version. The test is wired into `npm test`, so CI on every pull request (and `prepublishOnly` and `publish.yml` before publish) catches future release drift before it ships.

## Changes

- `test/version.js` — new test asserting `package.json` and `.claude-plugin/plugin.json` declare the same version, following the existing per-file harness idiom. Also guards the both-undefined case so a dropped `version` field cannot pass silently.
- `package.json` — append `node test/version.js` to the `test` script.
- `.claude-plugin/plugin.json` — bump version 1.2.1 → 1.3.0 to match `package.json`.

## Test plan

Locally executable:

- [x] `npm run check` — lint (js / sh / yml) plus format check plus the full test suite including the new version-consistency test. All pass.
- [x] `node test/version.js` — passes with the synced versions.

This is detection only. Releasing the synced version to the marketplace is handled by a separate release PR.
