### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-statusline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "author": {
     "name": "Cliff Wu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@z80020100/claude-code-statusline",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "main": "lib/statusline.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump package version from 1.3.0 to 1.3.1

## Highlights since v1.3.0

- Add a test asserting `package.json` and `.claude-plugin/plugin.json` always declare the same version and wire it into `npm test`
- Sync `.claude-plugin/plugin.json` to 1.3.0 to fix the marketplace manifest drift the v1.3.0 release left behind
- Bump all three version manifests (`package.json`, `package-lock.json`, `.claude-plugin/plugin.json`) together so the marketplace install path no longer reports a stale version

## Test plan

- [x] `npm run check` passes (lint + format + tests including the version-consistency guard)
