### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-statusline",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "author": {
     "name": "Cliff Wu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@z80020100/claude-code-statusline",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "main": "lib/statusline.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump package version from 1.3.1 to 1.3.2

## Highlights since v1.3.1

- Make the status lamp a clickable OSC 8 hyperlink to the status page (clickable in iTerm2 / Kitty / WezTerm and inert elsewhere)
- Note the clickable status lamp across the three READMEs

## Test plan

- [x] `npm run check` passes (lint + format + tests including the version-consistency guard)