### PR TITLE
Add opt-in live usage line with per-model weekly and credit spend

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,6 +21,7 @@
 - **セッションタイミング** — 実時間と API 応答時間を並列表示
 - **Git 連携** — ブランチ名、変更フラグ、worktree インジケーター、main との差分統計
 - **使用量制限モニタリング** — 現在 (5h) と週間 (7d) の使用量およびリセット時刻
+- **ライブ使用量表示（オプトイン）** — モデル別の週間使用量（例: Fable）と extra usage クレジット消費
 - **サービス稼働ランプ** — バナーの記号で Claude Code の可用性を一目で表示 (status.claude.com)。Cmd / Ctrl + クリックで開けます
 - **Sandbox インジケーター** — sandbox モードのオフ、オン、自動を表示
 - **パス圧縮** — 長いパスを自動短縮して80カラムに収める
@@ -145,13 +146,35 @@ claude-code-statusline update-check statusline off   # statusline セルフチ�
 1. `/plugin` を実行 → **Marketplaces** タブ → `claude-code-statusline` を選択 → **Enable auto-update** を選びます。
 2. プラグインが更新された後は `/clear` を実行するか Claude Code を再起動すると対応バージョンの CLI がインストールされます。
 
+### ライブ使用量
+
+オプトインの 8 行目にモデル別の週間使用量（例: Fable）と extra usage クレジット消費（`$使用済み/$上限 (%)`）を表示します。デフォルトでは無効です。データは Claude Code の `/usage` パネルと同じエンドポイントから取得します。バックグラウンド更新はその 1 回のリクエストのためだけに Claude Code の OAuth 認証情報（macOS Keychain または `~/.claude` / `CLAUDE_CONFIG_DIR` 配下の `.credentials.json`）を読み取ります。トークンがディスクやログに書き込まれることはありません。更新は分離したバックグラウンドプロセスで 5 分に 1 回まで実行され、表示用フィールドのみを `~/.claude/.cache/` にキャッシュします。描画をブロックすることはありません。各セグメントはアカウントに対応するデータがある場合のみ表示されます。macOS では初回のバックグラウンド取得時に Keychain の認可プロンプトが一度表示されることがあります。
+
+#### プラグインのスラッシュコマンド（推奨）
+
+```
+/claude-code-statusline:live-usage
+/claude-code-statusline:live-usage on
+/claude-code-statusline:live-usage off
+```
+
+#### CLI（代替）
+
+```sh
+claude-code-statusline live-usage        # 状態を表示
+claude-code-statusline live-usage on     # 有効化
+claude-code-statusline live-usage off    # 無効化
+```
+
+両方とも `~/.claude/claude-code-statusline.json` の `liveUsage` キーに書き込みます。`CLAUDE_STATUSLINE_LIVE_USAGE`（`1` または `true` で有効化、それ以外は無効化）を設定している場合は環境変数が優先されます。
+
 ### 表示レイアウト
 
 全フィールドを最大幅で表示した場合：
 
 ![全フィールド](assets/claude-code-statusline-simulation.png)
 
-ステータスラインは最大7行で表示されます — 各行は80文字以内に制限されます：
+ステータスラインは最大8行で表示されます — 各行は80文字以内に制限されます：
 
 | 行  | 内容                                                                                             |
 | --- | ------------------------------------------------------------------------------------------------ |
@@ -162,6 +185,7 @@ claude-code-statusline update-check statusline off   # statusline セルフチ�
 | 5   | プロジェクトディレクトリ、git ブランチ、変更フラグ、worktree インジケーター、main との差分       |
 | 6   | 現在の作業ディレクトリ（プロジェクトルートと異なる場合のみ表示）                                 |
 | 7   | 使用量制限 — 現在 (5h) と週間 (7d) の使用量およびリセット時刻                                    |
+| 8   | ライブ使用量（オプトイン）— モデル別の週間使用量と extra usage クレジット消費                    |
 
 #### サービス稼働ランプ
 
@@ -178,7 +202,7 @@ claude-code-statusline update-check statusline off   # statusline セルフチ�
 
 #### カラーゾーン
 
-コンテキストと使用量制限のバーは4段階グラデーションを使用します：
+コンテキスト、使用量制限、ライブ使用量のバーは4段階グラデーションを使用します：
 
 | 範囲    | 色       | 意味   |
 | ------- | -------- | ------ |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Custom status line for [Claude Code](https://docs.anthropic.com/en/docs/claude-c
 - **Session timing** — wall-clock and API duration side by side
 - **Git integration** — branch, dirty flag, worktree indicator, diff stats vs main
 - **Usage limit monitoring** — current (5h) and weekly (7d) usage with reset times
+- **Live usage line (opt-in)** — per-model weekly window (e.g. Fable) and extra usage credit spend
 - **Service health lamp** — the banner glyph signals Claude Code availability (status.claude.com) at a glance; Cmd/Ctrl-click to open it
 - **Sandbox indicator** — shows whether sandbox mode is off, on, or auto
 - **Path compression** — long paths auto-shorten to fit within 80 columns
@@ -145,13 +146,35 @@ When the indicator surfaces a newer release, upgrade through the path you used t
 1. Run `/plugin` → **Marketplaces** tab → select `claude-code-statusline` → choose **Enable auto-update**.
 2. After Claude Code updates the plugin, run `/clear` or restart Claude Code to install the matching CLI version.
 
+### Live Usage
+
+An opt-in line 8 shows the per-model weekly window (e.g. Fable) alongside extra usage credit spend (`$used/$limit (%)`). It is off by default. The data comes from the same endpoint the Claude Code `/usage` panel uses. The background refresh reads your Claude Code OAuth credentials (the macOS Keychain or `.credentials.json` under `~/.claude` or `CLAUDE_CONFIG_DIR`) for that single request; the token is never written to disk or logs. The refresh runs in a detached process at most once every 5 minutes and caches only the display fields under `~/.claude/.cache/`; rendering never blocks. Each segment appears only when the account has data for it. On macOS the first background fetch may show a one-time Keychain authorization prompt.
+
+#### Plugin slash command (recommended)
+
+```
+/claude-code-statusline:live-usage
+/claude-code-statusline:live-usage on
+/claude-code-statusline:live-usage off
+```
+
+#### CLI (alternative)
+
+```sh
+claude-code-statusline live-usage        # show state
+claude-code-statusline live-usage on     # enable
+claude-code-statusline live-usage off    # disable
+```
+
+Both write `~/.claude/claude-code-statusline.json` under the `liveUsage` key. `CLAUDE_STATUSLINE_LIVE_USAGE` (`1` or `true` to enable, otherwise disable) still takes precedence when set.
+
 ### Display Layout
 
 All fields at maximum width:
 
 ![All fields](https://raw.githubusercontent.com/z80020100/claude-code-statusline/main/assets/claude-code-statusline-simulation.png)
 
-The status line renders up to 7 lines — each constrained to 80 visible columns:
+The status line renders up to 8 lines — each constrained to 80 visible columns:
 
 | Line | Content                                                                                           |
 | ---- | ------------------------------------------------------------------------------------------------- |
@@ -162,6 +185,7 @@ The status line renders up to 7 lines — each constrained to 80 visible columns
 | 5    | Project directory, git branch, dirty flag, worktree indicator, diff vs main                       |
 | 6    | Current working directory (only when different from project root)                                 |
 | 7    | Usage limits — current (5h) and weekly (7d) with reset times                                      |
+| 8    | Live usage (opt-in) — per-model weekly window and extra usage credit spend                        |
 
 #### Service Health Lamp
 
@@ -178,7 +202,7 @@ The leading glyph on line 1 doubles as a traffic light for the **Claude Code** c
 
 #### Color Zones
 
-Context and usage limit bars use a 4-zone gradient:
+Context, usage limit, and live usage bars use a 4-zone gradient:
 
 | Range   | Color | Meaning  |
 | ------- | ----- | -------- |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -21,6 +21,7 @@
 - **Session 計時** — 同時顯示實際時間與 API 回應時間
 - **Git 整合** — 分支名稱、修改標記、worktree 指示器、與 main 的差異統計
 - **使用量限制監控** — 當前 (5h) 和每週 (7d) 使用量及重置時間
+- **即時用量顯示（opt-in）** — 各模型每週用量（如 Fable）與 extra usage credit 花費
 - **服務健康燈號** — banner 開頭符號一眼顯示 Claude Code 可用性 (status.claude.com);Cmd / Ctrl 點擊即可開啟
 - **Sandbox 指示器** — 顯示 sandbox 模式為關閉、開啟或自動
 - **路徑壓縮** — 長路徑自動縮短以符合 80 欄限制
@@ -145,13 +146,35 @@ claude-code-statusline update-check statusline off   # 停用 statusline 自我�
 1. 執行 `/plugin` → **Marketplaces** 分頁 → 選 `claude-code-statusline` → 選 **Enable auto-update**。
 2. Claude Code 自動更新 plugin 後須執行 `/clear` 或重啟 Claude Code 才會安裝對應版本的 CLI。
 
+### 即時用量
+
+opt-in 的第 8 行顯示各模型每週用量（如 Fable）與 extra usage credit 花費（`$已用/$上限 (%)`）。預設為關閉。資料來源與 Claude Code `/usage` 面板相同。背景更新會讀取你的 Claude Code OAuth 憑證（macOS Keychain 或 `~/.claude` / `CLAUDE_CONFIG_DIR` 下的 `.credentials.json`）且僅用於該次請求；token 絕不寫入磁碟或日誌。更新在分離的背景程序中執行每 5 分鐘至多一次且僅快取顯示欄位於 `~/.claude/.cache/`；渲染永不阻塞。各區段僅在帳號有對應資料時顯示。macOS 上第一次背景抓取可能出現一次性的 Keychain 授權提示。
+
+#### Plugin slash command（推薦）
+
+```
+/claude-code-statusline:live-usage
+/claude-code-statusline:live-usage on
+/claude-code-statusline:live-usage off
+```
+
+#### CLI（替代方式）
+
+```sh
+claude-code-statusline live-usage        # 顯示狀態
+claude-code-statusline live-usage on     # 啟用
+claude-code-statusline live-usage off    # 停用
+```
+
+兩者皆寫入 `~/.claude/claude-code-statusline.json` 的 `liveUsage` 鍵。設定 `CLAUDE_STATUSLINE_LIVE_USAGE`（`1` 或 `true` 啟用；其他值則停用）時仍會優先採用環境變數。
+
 ### 顯示佈局
 
 所有欄位最大寬度的呈現：
 
 ![所有欄位](assets/claude-code-statusline-simulation.png)
 
-狀態列最多顯示 7 行 — 每行限制在 80 個可見字元內：
+狀態列最多顯示 8 行 — 每行限制在 80 個可見字元內：
 
 | 行  | 內容                                                                                |
 | --- | ----------------------------------------------------------------------------------- |
@@ -162,6 +185,7 @@ claude-code-statusline update-check statusline off   # 停用 statusline 自我�
 | 5   | 專案目錄、git 分支、修改標記、worktree 指示器、與 main 的差異                       |
 | 6   | 目前工作目錄（僅在與專案根目錄不同時顯示）                                          |
 | 7   | 使用量限制 — 當前 (5h) 和每週 (7d) 使用量及重置時間                                 |
+| 8   | 即時用量（opt-in）— 各模型每週用量與 extra usage credit 花費                        |
 
 #### 服務健康燈號
 
@@ -178,7 +202,7 @@ claude-code-statusline update-check statusline off   # 停用 statusline 自我�
 
 #### 色彩區間
 
-上下文和使用量限制的進度條使用 4 段漸層：
+上下文、使用量限制和即時用量的進度條使用 4 段漸層：
 
 | 範圍    | 顏色 | 意義 |
 | ------- | ---- | ---- |

--- a/bin/claude-code-statusline.js
+++ b/bin/claude-code-statusline.js
@@ -25,6 +25,11 @@ if (arg === "setup") {
   const opts = {};
   if (process.argv[3]) opts.home = process.argv[3];
   runBackgroundCheck(opts).catch(() => {});
+} else if (arg === "__live-usage") {
+  const { runBackgroundCheck } = require("../lib/live-usage.js");
+  const opts = {};
+  if (process.argv[3]) opts.home = process.argv[3];
+  runBackgroundCheck(opts).catch(() => {});
 } else if (arg === "--version" || arg === "-v") {
   console.log(require("../package.json").version);
 } else if (arg === "--help" || arg === "-h" || process.stdin.isTTY) {

--- a/bin/claude-code-statusline.js
+++ b/bin/claude-code-statusline.js
@@ -10,6 +10,8 @@ if (arg === "setup") {
   require("../lib/icons.js").run(process.argv.slice(3));
 } else if (arg === "update-check") {
   require("../lib/update-check.js").run(process.argv.slice(3));
+} else if (arg === "live-usage") {
+  require("../lib/live-usage.js").run(process.argv.slice(3));
 } else if (arg === "__update-check") {
   const { runBackgroundCheck } = require("../lib/update-check.js");
   const opts = {
@@ -45,6 +47,9 @@ Usage:
   claude-code-statusline update-check claude off      Disable Claude Code update check
   claude-code-statusline update-check statusline on   Enable statusline self-update check
   claude-code-statusline update-check statusline off  Disable statusline self-update check
+  claude-code-statusline live-usage                   Show live usage display state
+  claude-code-statusline live-usage on                Enable live usage display
+  claude-code-statusline live-usage off               Disable live usage display
   claude-code-statusline --help                       Show this help message
   claude-code-statusline --version                    Show version
 

--- a/commands/live-usage.md
+++ b/commands/live-usage.md
@@ -1,0 +1,14 @@
+---
+description: Switch claude-code-statusline live usage display on/off or show current state
+argument-hint: [on|off]
+allowed-tools: Bash(claude-code-statusline:*)
+disable-model-invocation: true
+---
+
+Run this command exactly:
+
+```bash
+claude-code-statusline live-usage $ARGUMENTS
+```
+
+Show the CLI output verbatim. With no argument the CLI prints the live usage display state and the config path. Pass `on` or `off` to toggle. When enabled the status line adds a dedicated line with the per-model weekly window (e.g. Fable) and extra usage credit spend. State is written to `~/.claude/claude-code-statusline.json`. If you see "command not found" then run `/claude-code-statusline:setup` first to install the CLI.

--- a/lib/bg-cache.js
+++ b/lib/bg-cache.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+const https = require("https");
+
+// __dirname-relative so library consumers requiring the package main don't
+// spawn their host script by mistake.
+const CLI_PATH = path.resolve(
+  __dirname,
+  "..",
+  "bin",
+  "claude-code-statusline.js",
+);
+
+function cacheFile(home, name) {
+  return path.join(home, ".claude", ".cache", `${name}.json`);
+}
+
+function readCache(home, name) {
+  try {
+    const data = JSON.parse(fs.readFileSync(cacheFile(home, name), "utf8"));
+    return data && typeof data === "object" ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(data, home, name) {
+  const file = cacheFile(home, name);
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(data), "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isStale(cache, ttlMs) {
+  return !cache || !cache.checkedAt || Date.now() - cache.checkedAt > ttlMs;
+}
+
+function spawnDetached(args) {
+  try {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.unref();
+  } catch {}
+}
+
+function fetchJson(url, { timeoutMs, headers } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { timeout: timeoutMs, headers }, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        const err = new Error(`HTTP ${res.statusCode}`);
+        err.statusCode = res.statusCode;
+        reject(err);
+        return;
+      }
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch (err) {
+          reject(err);
+        }
+      });
+    });
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", reject);
+  });
+}
+
+module.exports = {
+  CLI_PATH,
+  readCache,
+  writeCache,
+  isStale,
+  spawnDetached,
+  fetchJson,
+};

--- a/lib/claude-status.js
+++ b/lib/claude-status.js
@@ -1,49 +1,23 @@
 "use strict";
 
-const fs = require("fs");
-const path = require("path");
 const os = require("os");
-const { spawn } = require("child_process");
-const https = require("https");
+
+const bg = require("./bg-cache.js");
 
 const COMPONENT_NAME = "Claude Code";
 const STATUS_URL = "https://status.claude.com/api/v2/components.json";
 const TTL_MS = 5 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 5000;
 const UA = `@z80020100/claude-code-statusline/claude-status`;
-const CLI_PATH = path.resolve(
-  __dirname,
-  "..",
-  "bin",
-  "claude-code-statusline.js",
-);
-
-function cachePath(home) {
-  return path.join(home, ".claude", ".cache", "claude-status.json");
-}
+const CLI_PATH = bg.CLI_PATH;
+const CACHE_NAME = "claude-status";
 
 function readCache(home) {
-  try {
-    const data = JSON.parse(fs.readFileSync(cachePath(home), "utf8"));
-    return data && typeof data === "object" ? data : null;
-  } catch {
-    return null;
-  }
+  return bg.readCache(home, CACHE_NAME);
 }
 
 function writeCache(data, home) {
-  const file = cachePath(home);
-  try {
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, JSON.stringify(data), "utf8");
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function isStale(cache) {
-  return !cache || !cache.checkedAt || Date.now() - cache.checkedAt > TTL_MS;
+  return bg.writeCache(data, home, CACHE_NAME);
 }
 
 function componentStatusFromResponse(data) {
@@ -53,37 +27,16 @@ function componentStatusFromResponse(data) {
   return typeof component?.status === "string" ? component.status : null;
 }
 
-function fetchComponentStatus() {
-  return new Promise((resolve, reject) => {
-    const req = https.get(
-      STATUS_URL,
-      { timeout: FETCH_TIMEOUT_MS, headers: { "user-agent": UA } },
-      (res) => {
-        if (res.statusCode !== 200) {
-          res.resume();
-          reject(new Error(`HTTP ${res.statusCode}`));
-          return;
-        }
-        let body = "";
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => (body += chunk));
-        res.on("end", () => {
-          try {
-            const status = componentStatusFromResponse(JSON.parse(body));
-            if (!status) {
-              reject(new Error("missing Claude Code component"));
-              return;
-            }
-            resolve(status);
-          } catch (err) {
-            reject(err);
-          }
-        });
-      },
-    );
-    req.on("timeout", () => req.destroy(new Error("timeout")));
-    req.on("error", reject);
+async function fetchComponentStatus() {
+  const data = await bg.fetchJson(STATUS_URL, {
+    timeoutMs: FETCH_TIMEOUT_MS,
+    headers: { "user-agent": UA },
   });
+  const status = componentStatusFromResponse(data);
+  if (!status) {
+    throw new Error("missing Claude Code component");
+  }
+  return status;
 }
 
 async function runBackgroundCheck({ home = os.homedir() } = {}) {
@@ -116,14 +69,7 @@ function reserveCheck({ home = os.homedir(), prev } = {}) {
 }
 
 function spawnBackgroundCheck(home) {
-  try {
-    const child = spawn(
-      process.execPath,
-      [CLI_PATH, "__claude-status", home ?? ""],
-      { detached: true, stdio: "ignore", windowsHide: true },
-    );
-    child.unref();
-  } catch {}
+  bg.spawnDetached(["__claude-status", home ?? ""]);
 }
 
 function peekStatus({
@@ -131,7 +77,7 @@ function peekStatus({
   spawnFn = spawnBackgroundCheck,
 } = {}) {
   const cache = readCache(home);
-  if (isStale(cache) && reserveCheck({ home, prev: cache })) {
+  if (bg.isStale(cache, TTL_MS) && reserveCheck({ home, prev: cache })) {
     spawnFn(home);
   }
   return {

--- a/lib/live-usage.js
+++ b/lib/live-usage.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const os = require("os");
+
+const { readConfig, writeConfig, configPath } = require("./config.js");
+
+const VALID_CLI_VALUES = { on: true, off: false };
+
+function isEnabled({ home = os.homedir(), configReader = readConfig } = {}) {
+  const env = process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
+  if (env !== undefined && env !== "") {
+    return env === "1" || env === "true";
+  }
+  try {
+    return configReader({ home }).liveUsage === true;
+  } catch {
+    return false;
+  }
+}
+
+function currentLiveUsage({ home = os.homedir() } = {}) {
+  return readConfig({ home }).liveUsage === true;
+}
+
+function setLiveUsage(value, { home = os.homedir() } = {}) {
+  if (!Object.hasOwn(VALID_CLI_VALUES, value)) {
+    throw new Error(`Invalid value "${value}". Expected "on" or "off".`);
+  }
+  return writeConfig({ liveUsage: VALID_CLI_VALUES[value] }, { home });
+}
+
+function run(args, { home = os.homedir() } = {}) {
+  try {
+    const value = args[0];
+    if (value === undefined) {
+      const state = currentLiveUsage({ home }) ? "on" : "off";
+      console.log(`Current live usage: ${state}`);
+      console.log(`Config: ${configPath(home)}`);
+      return;
+    }
+    setLiveUsage(value, { home });
+    console.log(`Set live usage to ${value}`);
+    console.log(`Wrote ${configPath(home)}`);
+  } catch (err) {
+    console.error("Error: " + err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { isEnabled, currentLiveUsage, setLiveUsage, run };

--- a/lib/live-usage.js
+++ b/lib/live-usage.js
@@ -1,10 +1,199 @@
 "use strict";
 
+const fs = require("fs");
 const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
 
 const { readConfig, writeConfig, configPath } = require("./config.js");
+const bg = require("./bg-cache.js");
 
 const VALID_CLI_VALUES = { on: true, off: false };
+const CACHE_NAME = "live-usage";
+const TTL_MS = 5 * 60 * 1000;
+const COOLDOWN_MS = 30 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10000;
+const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+// The endpoint is gated on a Claude Code user agent and this beta header.
+const UA = "claude-code/2.1.0";
+const OAUTH_BETA = "oauth-2025-04-20";
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+function readCache(home) {
+  return bg.readCache(home, CACHE_NAME);
+}
+
+function writeCache(data, home) {
+  return bg.writeCache(data, home, CACHE_NAME);
+}
+
+function readKeychainCredentials() {
+  if (process.platform !== "darwin") return null;
+  try {
+    return execFileSync(
+      "/usr/bin/security",
+      ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+      { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] },
+    );
+  } catch {
+    return null;
+  }
+}
+
+function readFileCredentials(home) {
+  const dir = process.env.CLAUDE_CONFIG_DIR || path.join(home, ".claude");
+  try {
+    return fs.readFileSync(path.join(dir, ".credentials.json"), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// The token stays in memory for the single request below and is never
+// written to the cache or logged.
+function readToken({
+  home = os.homedir(),
+  keychainReader = readKeychainCredentials,
+} = {}) {
+  const raw = keychainReader() || readFileCredentials(home);
+  if (!raw) return null;
+  try {
+    const token = JSON.parse(raw).claudeAiOauth?.accessToken;
+    return typeof token === "string" && token !== "" ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchUsage(token) {
+  return bg.fetchJson(USAGE_URL, {
+    timeoutMs: FETCH_TIMEOUT_MS,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "anthropic-beta": OAUTH_BETA,
+      "User-Agent": UA,
+    },
+  });
+}
+
+function epochSec(iso) {
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+}
+
+// Reduce the response to the fields the render needs. spend prefers the
+// canonical spend{} block and falls back to the older extra_usage{}.
+function extractUsage(data) {
+  const scopedRaw = (data?.limits ?? []).find(
+    (l) => l?.kind === "weekly_scoped" && l?.scope?.model?.display_name,
+  );
+  const scoped = scopedRaw
+    ? {
+        label: scopedRaw.scope.model.display_name,
+        percent: Number.isFinite(scopedRaw.percent)
+          ? Math.round(scopedRaw.percent)
+          : null,
+        resetsAt: epochSec(scopedRaw.resets_at),
+      }
+    : null;
+
+  const toSpend = (used, limit, exponent, currency, percent) => ({
+    usedMinor: used,
+    limitMinor: limit,
+    exponent: Number.isFinite(exponent) ? exponent : 2,
+    currency: currency ?? "USD",
+    percent: Number.isFinite(percent) ? Math.round(percent) : null,
+  });
+  const s = data?.spend;
+  const x = data?.extra_usage;
+  let spend = null;
+  if (
+    s?.enabled === true &&
+    Number.isFinite(s.used?.amount_minor) &&
+    Number.isFinite(s.limit?.amount_minor)
+  ) {
+    spend = toSpend(
+      s.used.amount_minor,
+      s.limit.amount_minor,
+      s.used.exponent,
+      s.used.currency,
+      s.percent,
+    );
+  } else if (
+    x?.is_enabled === true &&
+    Number.isFinite(x.used_credits) &&
+    Number.isFinite(x.monthly_limit)
+  ) {
+    spend = toSpend(
+      x.used_credits,
+      x.monthly_limit,
+      x.decimal_places,
+      x.currency,
+      x.utilization,
+    );
+  }
+  if (spend && spend.percent === null && spend.limitMinor > 0) {
+    spend.percent = Math.round((spend.usedMinor / spend.limitMinor) * 100);
+  }
+  return { scoped, spend };
+}
+
+// Fields carried forward when a check fails or is only being reserved.
+function carryForward(prev) {
+  return { scoped: prev?.scoped ?? null, spend: prev?.spend ?? null };
+}
+
+async function runBackgroundCheck({
+  home = os.homedir(),
+  tokenReader = readToken,
+  fetchFn = fetchUsage,
+} = {}) {
+  const token = tokenReader({ home });
+  if (!token) {
+    writeCache(
+      { checkedAt: Date.now(), ok: false, ...carryForward(readCache(home)) },
+      home,
+    );
+    return null;
+  }
+  try {
+    const { scoped, spend } = extractUsage(await fetchFn(token));
+    writeCache({ checkedAt: Date.now(), ok: true, scoped, spend }, home);
+    return { scoped, spend };
+  } catch (err) {
+    // JSON.stringify drops undefined so cooldownUntil only lands on 429.
+    writeCache(
+      {
+        checkedAt: Date.now(),
+        ok: false,
+        ...carryForward(readCache(home)),
+        cooldownUntil:
+          err?.statusCode === 429 ? Date.now() + COOLDOWN_MS : undefined,
+      },
+      home,
+    );
+    return null;
+  }
+}
+
+function reserveCheck({ home = os.homedir(), prev } = {}) {
+  const previous = prev !== undefined ? prev : readCache(home);
+  return writeCache(
+    {
+      checkedAt: Date.now(),
+      ok: previous?.ok ?? false,
+      ...carryForward(previous),
+      cooldownUntil: previous?.cooldownUntil,
+    },
+    home,
+  );
+}
+
+function spawnBackgroundCheck(home) {
+  bg.spawnDetached(["__live-usage", home ?? ""]);
+}
 
 function isEnabled({ home = os.homedir(), configReader = readConfig } = {}) {
   const env = process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
@@ -16,6 +205,26 @@ function isEnabled({ home = os.homedir(), configReader = readConfig } = {}) {
   } catch {
     return false;
   }
+}
+
+function peekLiveUsage({
+  home = os.homedir(),
+  configReader = readConfig,
+  spawnFn = spawnBackgroundCheck,
+} = {}) {
+  if (!isEnabled({ home, configReader })) return null;
+  const cache = readCache(home);
+  if (
+    bg.isStale(cache, TTL_MS) &&
+    !(cache?.cooldownUntil > Date.now()) &&
+    reserveCheck({ home, prev: cache })
+  ) {
+    spawnFn(home);
+  }
+  const scoped = cache?.scoped ?? null;
+  const spend = cache?.spend ?? null;
+  if (!scoped && !spend) return null;
+  return { scoped, spend };
 }
 
 function currentLiveUsage({ home = os.homedir() } = {}) {
@@ -47,4 +256,15 @@ function run(args, { home = os.homedir() } = {}) {
   }
 }
 
-module.exports = { isEnabled, currentLiveUsage, setLiveUsage, run };
+module.exports = {
+  isEnabled,
+  currentLiveUsage,
+  setLiveUsage,
+  run,
+  readToken,
+  extractUsage,
+  runBackgroundCheck,
+  reserveCheck,
+  peekLiveUsage,
+  writeCache,
+};

--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -7,6 +7,7 @@ const os = require("os");
 const { readConfig, configPath } = require("./config.js");
 const claudeStatus = require("./claude-status.js");
 const updateCheck = require("./update-check.js");
+const liveUsage = require("./live-usage.js");
 const PKG = require("../package.json");
 
 // Per-user tmp cache path — uid prefix isolates from other users on shared /tmp.
@@ -53,6 +54,7 @@ const ICON_SETS = {
  * @param {string} [options.iconMode] - Icon mode override ("nerd" or "unicode")
  * @param {object} [options.update] - { [target]: { available, latest } } — skip peekUpdate
  * @param {object|null} [options.claudeStatus] - { status } — skip peekStatus
+ * @param {object|null} [options.liveUsage] - { scoped, spend } — skip peekLiveUsage
  * @param {string} [options.home] - Home directory override
  * @param {Date}   [options.now] - Current time override
  * @returns {string[]} Array of ANSI-colored lines
@@ -574,13 +576,14 @@ function render(data, options = {}) {
 
   // Banner shows both versions whenever Claude Code data carries a version;
   // update arrows stay gated on each target's update-check toggle.
+  // At most one config read per render shared by the peek calls below.
+  let cfg;
+  const cfgReader = () => (cfg ??= readConfig({ home }));
+
   let claudeUpdateSuffix = "";
   let statuslineSegment = "";
   let lamp = null;
   if (version) {
-    // One config read shared by both peekUpdate calls.
-    const cfg = readConfig({ home });
-    const cfgReader = () => cfg;
     const peek = (target, currentVersion) =>
       options.update?.[target] ??
       updateCheck.peekUpdate({
@@ -710,6 +713,50 @@ function render(data, options = {}) {
     fmtRate(usageData?.seven_day, "weekly"),
   ];
 
+  // Live usage line: per-model weekly window + extra usage credit spend
+  function fmtSpend(spend) {
+    if (
+      !Number.isFinite(spend.usedMinor) ||
+      !Number.isFinite(spend.limitMinor) ||
+      !Number.isFinite(spend.percent)
+    ) {
+      return "";
+    }
+    const exp = Number.isFinite(spend.exponent) ? spend.exponent : 2;
+    const money = (m) => {
+      const value = (m / 10 ** exp).toFixed(exp);
+      return spend.currency === "USD"
+        ? `$${value}`
+        : `${spend.currency} ${value}`;
+    };
+    return (
+      `${gray}extra${reset} ${buildBar(spend.percent, barWidth)} ` +
+      `${colorForPct(spend.percent)}${money(spend.usedMinor)}${reset}` +
+      `${darkGray}/${reset}${softWhite}${money(spend.limitMinor)}${reset} ` +
+      `${colorForPct(spend.percent)}(${spend.percent}%)${reset}`
+    );
+  }
+  const live =
+    options.liveUsage !== undefined
+      ? options.liveUsage
+      : liveUsage.peekLiveUsage({ home, configReader: cfgReader });
+  const liveParts = [];
+  if (live?.scoped) {
+    liveParts.push(
+      fmtRate(
+        {
+          used_percentage: live.scoped.percent,
+          resets_at: live.scoped.resetsAt,
+        },
+        live.scoped.label,
+      ),
+    );
+  }
+  if (live?.spend) {
+    const spendPart = fmtSpend(live.spend);
+    if (spendPart) liveParts.push(spendPart);
+  }
+
   // ── Collect output lines ────────────────────────────
   const output = [];
   if (versionLine) {
@@ -721,6 +768,7 @@ function render(data, options = {}) {
   if (workspaceParts.length > 0) output.push(workspaceParts.join(sep));
   if (cwdParts.length > 0) output.push(cwdParts.join(sep));
   output.push(rateParts.join(sep));
+  if (liveParts.length > 0) output.push(liveParts.join(sep));
 
   return output;
 }

--- a/lib/update-check.js
+++ b/lib/update-check.js
@@ -1,12 +1,9 @@
 "use strict";
 
-const fs = require("fs");
-const path = require("path");
 const os = require("os");
-const { spawn } = require("child_process");
-const https = require("https");
 
 const { readConfig, writeConfig, configPath } = require("./config.js");
+const bg = require("./bg-cache.js");
 
 const TTL_MS = 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 5000;
@@ -17,41 +14,14 @@ const TARGETS = {
   statusline: { pkg: "@z80020100/claude-code-statusline" },
 };
 const TARGET_NAMES = Object.keys(TARGETS);
-// __dirname-relative so library consumers requiring the package main don't
-// spawn their host script by mistake.
-const CLI_PATH = path.resolve(
-  __dirname,
-  "..",
-  "bin",
-  "claude-code-statusline.js",
-);
-
-function cachePath(home, target) {
-  return path.join(home, ".claude", ".cache", `update-check-${target}.json`);
-}
+const CLI_PATH = bg.CLI_PATH;
 
 function readCache(home, target) {
-  try {
-    const data = JSON.parse(fs.readFileSync(cachePath(home, target), "utf8"));
-    return data && typeof data === "object" ? data : null;
-  } catch {
-    return null;
-  }
+  return bg.readCache(home, `update-check-${target}`);
 }
 
 function writeCache(data, home, target) {
-  const file = cachePath(home, target);
-  try {
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, JSON.stringify(data), "utf8");
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function isStale(cache) {
-  return !cache || !cache.checkedAt || Date.now() - cache.checkedAt > TTL_MS;
+  return bg.writeCache(data, home, `update-check-${target}`);
 }
 
 function compareSemver(a, b) {
@@ -95,38 +65,15 @@ function compareSemver(a, b) {
   return 0;
 }
 
-function fetchLatestVersion(pkg) {
-  const url = `https://registry.npmjs.org/${pkg}/latest`;
-  return new Promise((resolve, reject) => {
-    const req = https.get(
-      url,
-      { timeout: FETCH_TIMEOUT_MS, headers: { "user-agent": UA } },
-      (res) => {
-        if (res.statusCode !== 200) {
-          res.resume();
-          reject(new Error(`HTTP ${res.statusCode}`));
-          return;
-        }
-        let body = "";
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => (body += chunk));
-        res.on("end", () => {
-          try {
-            const data = JSON.parse(body);
-            if (!data || typeof data.version !== "string") {
-              reject(new Error("invalid response"));
-              return;
-            }
-            resolve(data.version);
-          } catch (err) {
-            reject(err);
-          }
-        });
-      },
-    );
-    req.on("timeout", () => req.destroy(new Error("timeout")));
-    req.on("error", reject);
+async function fetchLatestVersion(pkg) {
+  const data = await bg.fetchJson(`https://registry.npmjs.org/${pkg}/latest`, {
+    timeoutMs: FETCH_TIMEOUT_MS,
+    headers: { "user-agent": UA },
   });
+  if (!data || typeof data.version !== "string") {
+    throw new Error("invalid response");
+  }
+  return data.version;
 }
 
 async function runBackgroundCheck({
@@ -163,14 +110,12 @@ function reserveCheck({ target, current, home = os.homedir(), prev } = {}) {
 }
 
 function spawnBackgroundCheck(target, currentVersion, home) {
-  try {
-    const child = spawn(
-      process.execPath,
-      [CLI_PATH, "__update-check", target, currentVersion ?? "", home ?? ""],
-      { detached: true, stdio: "ignore", windowsHide: true },
-    );
-    child.unref();
-  } catch {}
+  bg.spawnDetached([
+    "__update-check",
+    target,
+    currentVersion ?? "",
+    home ?? "",
+  ]);
 }
 
 function isEnabled({
@@ -200,7 +145,7 @@ function peekUpdate({
     return { available: false, latest: null };
   const cache = readCache(home, target);
   if (
-    isStale(cache) &&
+    bg.isStale(cache, TTL_MS) &&
     reserveCheck({ target, current: currentVersion, home, prev: cache })
   ) {
     spawnFn(target, currentVersion, home);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "check": "npm run lint && npm run format:check && npm run test",
     "fix": "npm run lint:fix && npm run format:fix",
-    "test": "node test/measure-width.js --check && node test/config.js && node test/update-check.js && node test/claude-status.js && node test/hook.js && node test/cli.js && node test/version.js",
+    "test": "node test/measure-width.js --check && node test/config.js && node test/update-check.js && node test/live-usage.js && node test/claude-status.js && node test/hook.js && node test/cli.js && node test/version.js",
     "simulate": "node test/measure-width.js",
     "ci:local": "act push --container-architecture linux/amd64",
     "lint": "npm run lint:js && npm run lint:sh && npm run lint:yml",

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -10,6 +10,7 @@ local_files_present() {
     [[ -f "${CONFIG}" ]] ||
         [[ -f "${CACHE_DIR}/update-check-claude.json" ]] ||
         [[ -f "${CACHE_DIR}/update-check-statusline.json" ]] ||
+        [[ -f "${CACHE_DIR}/live-usage.json" ]] ||
         [[ -d "${PLUGIN_DATA_DIR}" ]]
 }
 
@@ -40,6 +41,7 @@ fi
 remove_file "${CONFIG}"
 remove_file "${CACHE_DIR}/update-check-claude.json"
 remove_file "${CACHE_DIR}/update-check-statusline.json"
+remove_file "${CACHE_DIR}/live-usage.json"
 remove_dir "${PLUGIN_DATA_DIR}"
 
 if plugin_installed; then

--- a/test/cli.js
+++ b/test/cli.js
@@ -17,6 +17,7 @@ const {
   writeCache: writeClaudeStatusCache,
 } = require("../lib/claude-status.js");
 const { writeCache } = require("../lib/update-check.js");
+const { writeCache: writeLiveUsageCache } = require("../lib/live-usage.js");
 
 let failed = 0;
 
@@ -1199,6 +1200,65 @@ test("live-usage rejects invalid value", () => {
         "missing invalid value message",
       );
     }
+  });
+});
+
+// ── live usage render line ───────────────────────────
+
+const LIVE_CACHE = {
+  checkedAt: Date.now(),
+  ok: true,
+  scoped: { label: "Fable", percent: 0, resetsAt: 4070908800 },
+  spend: {
+    usedMinor: 0,
+    limitMinor: 5000,
+    percent: 0,
+    exponent: 2,
+    currency: "USD",
+  },
+};
+
+test("live usage line stays hidden when toggle is off", () => {
+  withTmpHome((tmp) => {
+    writeLiveUsageCache(LIVE_CACHE, tmp);
+    const input = JSON.stringify({ model: { display_name: "M" } });
+    const out = run([], { input, env: cleanEnv({ HOME: tmp }) });
+    assert(!out.includes("Fable"), "unexpected live usage line");
+  });
+});
+
+test("live usage line renders scoped and spend when enabled", () => {
+  withTmpHome((tmp) => {
+    seedConfig(tmp, { liveUsage: true });
+    writeLiveUsageCache(LIVE_CACHE, tmp);
+    const input = JSON.stringify({ model: { display_name: "M" } });
+    const out = stripAnsi(run([], { input, env: cleanEnv({ HOME: tmp }) }));
+    assert(out.includes("Fable"), `missing scoped segment: ${out}`);
+    assert(out.includes("0%"), "missing scoped percent");
+    assert(out.includes("$0.00/$50.00 (0%)"), `missing spend segment: ${out}`);
+  });
+});
+
+test("live usage line renders spend segment alone", () => {
+  withTmpHome((tmp) => {
+    seedConfig(tmp, { liveUsage: true });
+    writeLiveUsageCache({ ...LIVE_CACHE, scoped: null }, tmp);
+    const input = JSON.stringify({ model: { display_name: "M" } });
+    const out = stripAnsi(run([], { input, env: cleanEnv({ HOME: tmp }) }));
+    assert(!out.includes("Fable"), "unexpected scoped segment");
+    assert(out.includes("extra"), "missing spend label");
+  });
+});
+
+test("env override enables live usage line without config", () => {
+  withTmpHome((tmp) => {
+    writeLiveUsageCache(LIVE_CACHE, tmp);
+    const input = JSON.stringify({ model: { display_name: "M" } });
+    const out = run([], {
+      input,
+      env: cleanEnv({ HOME: tmp, CLAUDE_STATUSLINE_LIVE_USAGE: "1" }),
+    });
+    assert(out.includes("Fable"), `missing live usage line: ${out}`);
   });
 });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -92,6 +92,10 @@ test("--help prints complete help output", () => {
     out.includes("claude-code-statusline update-check"),
     "missing update-check command",
   );
+  assert(
+    out.includes("claude-code-statusline live-usage"),
+    "missing live-usage command",
+  );
   assert(out.includes(PKG.author), "missing author");
   assert(out.includes(PKG.license), "missing license");
 });
@@ -514,6 +518,7 @@ function cleanEnv(extra) {
   delete env.CLAUDE_STATUSLINE_ICONS;
   delete env.CLAUDE_CODE_EFFORT_LEVEL;
   delete env.CLAUDE_STATUSLINE_UPDATE_CHECK;
+  delete env.CLAUDE_STATUSLINE_LIVE_USAGE;
   return { ...env, ...extra };
 }
 
@@ -1120,6 +1125,80 @@ test("update-check rejects invalid value", () => {
       ),
     );
     assert(cfg.updateCheck?.claude === true, "config should not change");
+  });
+});
+
+// ── live-usage CLI command ───────────────────────────
+
+test("live-usage reports off by default", () => {
+  withTmpHome((tmp) => {
+    const out = run(["live-usage"], { env: cleanEnv({ HOME: tmp }) });
+    assert(out.includes("Current live usage: off"), `unexpected: ${out}`);
+    assert(out.includes("claude-code-statusline.json"), "missing config path");
+  });
+});
+
+test("live-usage on enables the toggle", () => {
+  withTmpHome((tmp) => {
+    const out = run(["live-usage", "on"], { env: cleanEnv({ HOME: tmp }) });
+    assert(out.includes("Set live usage to on"), `unexpected: ${out}`);
+    const cfg = JSON.parse(
+      fs.readFileSync(
+        path.join(tmp, ".claude", "claude-code-statusline.json"),
+        "utf8",
+      ),
+    );
+    assert(cfg.liveUsage === true, "config not persisted");
+    const show = run(["live-usage"], { env: cleanEnv({ HOME: tmp }) });
+    assert(show.includes("Current live usage: on"), "state not reported");
+  });
+});
+
+test("live-usage off disables the toggle", () => {
+  withTmpHome((tmp) => {
+    seedConfig(tmp, { liveUsage: true });
+    const out = run(["live-usage", "off"], { env: cleanEnv({ HOME: tmp }) });
+    assert(out.includes("Set live usage to off"), `unexpected: ${out}`);
+    const cfg = JSON.parse(
+      fs.readFileSync(
+        path.join(tmp, ".claude", "claude-code-statusline.json"),
+        "utf8",
+      ),
+    );
+    assert(cfg.liveUsage === false, "config not persisted");
+  });
+});
+
+test("live-usage preserves existing config keys", () => {
+  withTmpHome((tmp) => {
+    seedConfig(tmp, { icons: "nerd" });
+    run(["live-usage", "on"], { env: cleanEnv({ HOME: tmp }) });
+    const cfg = JSON.parse(
+      fs.readFileSync(
+        path.join(tmp, ".claude", "claude-code-statusline.json"),
+        "utf8",
+      ),
+    );
+    assert(cfg.icons === "nerd", "icons key lost");
+    assert(cfg.liveUsage === true, "liveUsage not set");
+  });
+});
+
+test("live-usage rejects invalid value", () => {
+  withTmpHome((tmp) => {
+    try {
+      run(["live-usage", "yes"], {
+        env: cleanEnv({ HOME: tmp }),
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      throw new Error("expected command to fail");
+    } catch (err) {
+      assert(err.status === 1, "expected exit code 1");
+      assert(
+        err.stderr.includes('Expected "on" or "off".'),
+        "missing invalid value message",
+      );
+    }
   });
 });
 

--- a/test/live-usage.js
+++ b/test/live-usage.js
@@ -10,20 +10,42 @@ const {
   isEnabled,
   currentLiveUsage,
   setLiveUsage,
+  readToken,
+  extractUsage,
+  runBackgroundCheck,
+  peekLiveUsage,
+  writeCache,
 } = require("../lib/live-usage.js");
 
 delete process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
 
 let failed = 0;
 
+function report(name, err) {
+  if (!err) {
+    console.log(`\x1b[38;5;114m✓\x1b[0m ${name}`);
+    return;
+  }
+  failed++;
+  console.log(`\x1b[38;5;167m✗\x1b[0m ${name}`);
+  console.log(`  ${err.message}`);
+}
+
 function test(name, fn) {
   try {
     fn();
-    console.log(`\x1b[38;5;114m✓\x1b[0m ${name}`);
+    report(name);
   } catch (err) {
-    failed++;
-    console.log(`\x1b[38;5;167m✗\x1b[0m ${name}`);
-    console.log(`  ${err.message}`);
+    report(name, err);
+  }
+}
+
+async function testAsync(name, fn) {
+  try {
+    await fn();
+    report(name);
+  } catch (err) {
+    report(name, err);
   }
 }
 
@@ -40,19 +62,67 @@ function withTmpHome(fn) {
   }
 }
 
-function withEnv(value, fn) {
-  const prev = process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
-  process.env.CLAUDE_STATUSLINE_LIVE_USAGE = value;
+async function withTmpHomeAsync(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "live-usage-test-"));
+  try {
+    await fn(tmp);
+  } finally {
+    fs.rmSync(tmp, { recursive: true });
+  }
+}
+
+function withEnv(name, value, fn) {
+  const prev = process.env[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
   try {
     fn();
   } finally {
     if (prev === undefined) {
-      delete process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
+      delete process.env[name];
     } else {
-      process.env.CLAUDE_STATUSLINE_LIVE_USAGE = prev;
+      process.env[name] = prev;
     }
   }
 }
+
+function cacheFilePath(home) {
+  return path.join(home, ".claude", ".cache", "live-usage.json");
+}
+
+function readCacheJson(home) {
+  return JSON.parse(fs.readFileSync(cacheFilePath(home), "utf8"));
+}
+
+const FIXTURE = {
+  limits: [
+    { kind: "session", percent: 12, resets_at: "2099-01-01T00:00:00Z" },
+    { kind: "weekly_all", percent: 34, resets_at: "2099-01-02T00:00:00Z" },
+    {
+      kind: "weekly_scoped",
+      percent: 0,
+      resets_at: "2099-01-03T00:00:00Z",
+      scope: { model: { id: null, display_name: "Fable" } },
+    },
+  ],
+  spend: {
+    used: { amount_minor: 0, currency: "USD", exponent: 2 },
+    limit: { amount_minor: 5000, currency: "USD", exponent: 2 },
+    percent: 0,
+    enabled: true,
+  },
+  extra_usage: {
+    is_enabled: true,
+    used_credits: 0,
+    monthly_limit: 5000,
+    utilization: 0,
+    currency: "USD",
+    decimal_places: 2,
+  },
+};
 
 // ── isEnabled ────────────────────────────────────────
 
@@ -99,13 +169,13 @@ test("isEnabled returns false when config reader throws", () => {
 test("env override 1/true enables regardless of config", () => {
   withTmpHome((tmp) => {
     const off = () => ({ liveUsage: false });
-    withEnv("1", () => {
+    withEnv("CLAUDE_STATUSLINE_LIVE_USAGE", "1", () => {
       assert(
         isEnabled({ home: tmp, configReader: off }) === true,
         "expected true for 1",
       );
     });
-    withEnv("true", () => {
+    withEnv("CLAUDE_STATUSLINE_LIVE_USAGE", "true", () => {
       assert(
         isEnabled({ home: tmp, configReader: off }) === true,
         "expected true for true",
@@ -117,13 +187,13 @@ test("env override 1/true enables regardless of config", () => {
 test("env override 0/false disables regardless of config", () => {
   withTmpHome((tmp) => {
     const on = () => ({ liveUsage: true });
-    withEnv("0", () => {
+    withEnv("CLAUDE_STATUSLINE_LIVE_USAGE", "0", () => {
       assert(
         isEnabled({ home: tmp, configReader: on }) === false,
         "expected false for 0",
       );
     });
-    withEnv("false", () => {
+    withEnv("CLAUDE_STATUSLINE_LIVE_USAGE", "false", () => {
       assert(
         isEnabled({ home: tmp, configReader: on }) === false,
         "expected false for false",
@@ -134,7 +204,7 @@ test("env override 0/false disables regardless of config", () => {
 
 test("empty env falls through to config", () => {
   withTmpHome((tmp) => {
-    withEnv("", () => {
+    withEnv("CLAUDE_STATUSLINE_LIVE_USAGE", "", () => {
       assert(
         isEnabled({ home: tmp, configReader: () => ({ liveUsage: true }) }) ===
           true,
@@ -173,12 +243,286 @@ test("setLiveUsage rejects invalid value", () => {
   });
 });
 
-// ── summary ──────────────────────────────────────────
+// ── extractUsage ─────────────────────────────────────
 
-console.log();
-if (failed > 0) {
-  console.log(`\x1b[38;5;167m${failed} test(s) failed\x1b[0m`);
-  process.exit(1);
-} else {
-  console.log("\x1b[38;5;114mall tests passed\x1b[0m");
-}
+test("extractUsage reads scoped window and spend", () => {
+  const { scoped, spend } = extractUsage(FIXTURE);
+  assert(scoped !== null, "expected scoped");
+  assert(scoped.label === "Fable", "expected Fable label");
+  assert(scoped.percent === 0, "expected percent 0");
+  assert(
+    scoped.resetsAt === Math.floor(Date.parse("2099-01-03T00:00:00Z") / 1000),
+    "expected epoch seconds resetsAt",
+  );
+  assert(spend !== null, "expected spend");
+  assert(spend.usedMinor === 0, "expected usedMinor 0");
+  assert(spend.limitMinor === 5000, "expected limitMinor 5000");
+  assert(spend.percent === 0, "expected percent 0");
+  assert(spend.exponent === 2, "expected exponent 2");
+  assert(spend.currency === "USD", "expected USD");
+});
+
+test("extractUsage falls back to extra_usage when spend is absent", () => {
+  const data = { ...FIXTURE, spend: undefined };
+  const { spend } = extractUsage(data);
+  assert(spend !== null, "expected spend from extra_usage");
+  assert(spend.usedMinor === 0, "expected usedMinor 0");
+  assert(spend.percent === 0, "expected utilization percent");
+});
+
+test("extractUsage returns null spend when disabled", () => {
+  const data = {
+    spend: { ...FIXTURE.spend, enabled: false },
+    extra_usage: { ...FIXTURE.extra_usage, is_enabled: false },
+  };
+  const { spend } = extractUsage(data);
+  assert(spend === null, "expected null spend");
+});
+
+test("extractUsage ignores scoped entries without display_name", () => {
+  const data = {
+    limits: [{ kind: "weekly_scoped", percent: 10, scope: { model: {} } }],
+  };
+  const { scoped } = extractUsage(data);
+  assert(scoped === null, "expected null scoped");
+});
+
+test("extractUsage handles empty response", () => {
+  const { scoped, spend } = extractUsage({});
+  assert(scoped === null, "expected null scoped");
+  assert(spend === null, "expected null spend");
+});
+
+// ── readToken ────────────────────────────────────────
+
+const CREDS = JSON.stringify({ claudeAiOauth: { accessToken: "tok-abc" } });
+
+test("readToken prefers the keychain reader", () => {
+  withTmpHome((tmp) => {
+    const token = readToken({ home: tmp, keychainReader: () => CREDS });
+    assert(token === "tok-abc", "expected keychain token");
+  });
+});
+
+test("readToken falls back to the credentials file", () => {
+  withTmpHome((tmp) => {
+    withEnv("CLAUDE_CONFIG_DIR", undefined, () => {
+      const dir = path.join(tmp, ".claude");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, ".credentials.json"), CREDS);
+      const token = readToken({ home: tmp, keychainReader: () => null });
+      assert(token === "tok-abc", "expected file token");
+    });
+  });
+});
+
+test("readToken honors CLAUDE_CONFIG_DIR", () => {
+  withTmpHome((tmp) => {
+    const dir = path.join(tmp, "custom-config");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, ".credentials.json"), CREDS);
+    withEnv("CLAUDE_CONFIG_DIR", dir, () => {
+      const token = readToken({
+        home: path.join(tmp, "elsewhere"),
+        keychainReader: () => null,
+      });
+      assert(token === "tok-abc", "expected CLAUDE_CONFIG_DIR token");
+    });
+  });
+});
+
+test("readToken returns null when no source is available", () => {
+  withTmpHome((tmp) => {
+    withEnv("CLAUDE_CONFIG_DIR", undefined, () => {
+      const token = readToken({ home: tmp, keychainReader: () => null });
+      assert(token === null, "expected null");
+    });
+  });
+});
+
+test("readToken returns null on malformed credentials", () => {
+  withTmpHome((tmp) => {
+    assert(
+      readToken({ home: tmp, keychainReader: () => "not json" }) === null,
+      "expected null for bad JSON",
+    );
+    assert(
+      readToken({ home: tmp, keychainReader: () => "{}" }) === null,
+      "expected null for missing token",
+    );
+  });
+});
+
+// ── peekLiveUsage ────────────────────────────────────
+
+test("peekLiveUsage returns null and skips spawn when disabled", () => {
+  withTmpHome((tmp) => {
+    let spawnCount = 0;
+    const result = peekLiveUsage({
+      home: tmp,
+      configReader: () => ({ liveUsage: false }),
+      spawnFn: () => {
+        spawnCount++;
+      },
+    });
+    assert(result === null, "expected null");
+    assert(spawnCount === 0, "expected no spawn");
+  });
+});
+
+test("peekLiveUsage spawns once when enabled with no cache", () => {
+  withTmpHome((tmp) => {
+    let spawnCount = 0;
+    const result = peekLiveUsage({
+      home: tmp,
+      configReader: () => ({ liveUsage: true }),
+      spawnFn: () => {
+        spawnCount++;
+      },
+    });
+    assert(spawnCount === 1, `expected one spawn got ${spawnCount}`);
+    assert(result === null, "expected null before first fetch");
+  });
+});
+
+test("peekLiveUsage returns cached data without spawning when fresh", () => {
+  withTmpHome((tmp) => {
+    writeCache(
+      {
+        checkedAt: Date.now(),
+        ok: true,
+        scoped: { label: "Fable", percent: 0, resetsAt: 1 },
+        spend: null,
+      },
+      tmp,
+    );
+    let spawnCount = 0;
+    const result = peekLiveUsage({
+      home: tmp,
+      configReader: () => ({ liveUsage: true }),
+      spawnFn: () => {
+        spawnCount++;
+      },
+    });
+    assert(spawnCount === 0, "expected no spawn");
+    assert(result?.scoped?.percent === 0, "expected cached scoped data");
+  });
+});
+
+test("peekLiveUsage suppresses spawn during cooldown", () => {
+  withTmpHome((tmp) => {
+    writeCache(
+      {
+        checkedAt: 1,
+        ok: false,
+        scoped: { label: "Fable", percent: 0, resetsAt: 1 },
+        spend: null,
+        cooldownUntil: Date.now() + 60000,
+      },
+      tmp,
+    );
+    let spawnCount = 0;
+    const result = peekLiveUsage({
+      home: tmp,
+      configReader: () => ({ liveUsage: true }),
+      spawnFn: () => {
+        spawnCount++;
+      },
+    });
+    assert(spawnCount === 0, "expected no spawn during cooldown");
+    assert(result?.scoped?.percent === 0, "expected stale data returned");
+  });
+});
+
+// ── runBackgroundCheck (async) ───────────────────────
+
+(async () => {
+  await testAsync("runBackgroundCheck caches extracted usage", async () => {
+    await withTmpHomeAsync(async (tmp) => {
+      await runBackgroundCheck({
+        home: tmp,
+        tokenReader: () => "tok-secret-123",
+        fetchFn: async () => FIXTURE,
+      });
+      const raw = fs.readFileSync(cacheFilePath(tmp), "utf8");
+      const cache = JSON.parse(raw);
+      assert(cache.ok === true, "expected ok true");
+      assert(cache.scoped.label === "Fable", "expected scoped label");
+      assert(cache.spend.usedMinor === 0, "expected spend cached");
+      assert(!raw.includes("tok-secret-123"), "token must never be cached");
+    });
+  });
+
+  await testAsync(
+    "runBackgroundCheck keeps data when token is missing",
+    async () => {
+      await withTmpHomeAsync(async (tmp) => {
+        writeCache(
+          {
+            checkedAt: 1,
+            ok: true,
+            scoped: { label: "Fable", percent: 10, resetsAt: 1 },
+            spend: null,
+          },
+          tmp,
+        );
+        const result = await runBackgroundCheck({
+          home: tmp,
+          tokenReader: () => null,
+          fetchFn: async () => {
+            throw new Error("must not fetch without token");
+          },
+        });
+        assert(result === null, "expected null result");
+        const cache = readCacheJson(tmp);
+        assert(cache.ok === false, "expected ok false");
+        assert(cache.scoped.percent === 10, "expected previous data kept");
+      });
+    },
+  );
+
+  await testAsync("runBackgroundCheck sets cooldown on HTTP 429", async () => {
+    await withTmpHomeAsync(async (tmp) => {
+      await runBackgroundCheck({
+        home: tmp,
+        tokenReader: () => "tok",
+        fetchFn: async () => {
+          const err = new Error("HTTP 429");
+          err.statusCode = 429;
+          throw err;
+        },
+      });
+      const cache = readCacheJson(tmp);
+      assert(cache.ok === false, "expected ok false");
+      assert(cache.cooldownUntil > Date.now(), "expected future cooldown");
+    });
+  });
+
+  await testAsync(
+    "runBackgroundCheck omits cooldown on other errors",
+    async () => {
+      await withTmpHomeAsync(async (tmp) => {
+        await runBackgroundCheck({
+          home: tmp,
+          tokenReader: () => "tok",
+          fetchFn: async () => {
+            throw new Error("timeout");
+          },
+        });
+        const cache = readCacheJson(tmp);
+        assert(cache.ok === false, "expected ok false");
+        assert(!("cooldownUntil" in cache), "expected no cooldown");
+      });
+    },
+  );
+
+  // ── summary ────────────────────────────────────────
+
+  console.log();
+  if (failed > 0) {
+    console.log(`\x1b[38;5;167m${failed} test(s) failed\x1b[0m`);
+    process.exit(1);
+  } else {
+    console.log("\x1b[38;5;114mall tests passed\x1b[0m");
+  }
+})();

--- a/test/live-usage.js
+++ b/test/live-usage.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  isEnabled,
+  currentLiveUsage,
+  setLiveUsage,
+} = require("../lib/live-usage.js");
+
+delete process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
+
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`\x1b[38;5;114m✓\x1b[0m ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`\x1b[38;5;167m✗\x1b[0m ${name}`);
+    console.log(`  ${err.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function withTmpHome(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "live-usage-test-"));
+  try {
+    fn(tmp);
+  } finally {
+    fs.rmSync(tmp, { recursive: true });
+  }
+}
+
+function withEnv(value, fn) {
+  const prev = process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
+  process.env.CLAUDE_STATUSLINE_LIVE_USAGE = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.CLAUDE_STATUSLINE_LIVE_USAGE;
+    } else {
+      process.env.CLAUDE_STATUSLINE_LIVE_USAGE = prev;
+    }
+  }
+}
+
+// ── isEnabled ────────────────────────────────────────
+
+test("isEnabled defaults to false with no config", () => {
+  withTmpHome((tmp) => {
+    assert(isEnabled({ home: tmp }) === false, "expected false");
+  });
+});
+
+test("isEnabled reads liveUsage true from config", () => {
+  withTmpHome((tmp) => {
+    assert(
+      isEnabled({ home: tmp, configReader: () => ({ liveUsage: true }) }) ===
+        true,
+      "expected true",
+    );
+  });
+});
+
+test("isEnabled requires strict boolean true", () => {
+  withTmpHome((tmp) => {
+    assert(
+      isEnabled({ home: tmp, configReader: () => ({ liveUsage: "true" }) }) ===
+        false,
+      "expected false for non-boolean",
+    );
+  });
+});
+
+test("isEnabled returns false when config reader throws", () => {
+  withTmpHome((tmp) => {
+    assert(
+      isEnabled({
+        home: tmp,
+        configReader: () => {
+          throw new Error("boom");
+        },
+      }) === false,
+      "expected false",
+    );
+  });
+});
+
+test("env override 1/true enables regardless of config", () => {
+  withTmpHome((tmp) => {
+    const off = () => ({ liveUsage: false });
+    withEnv("1", () => {
+      assert(
+        isEnabled({ home: tmp, configReader: off }) === true,
+        "expected true for 1",
+      );
+    });
+    withEnv("true", () => {
+      assert(
+        isEnabled({ home: tmp, configReader: off }) === true,
+        "expected true for true",
+      );
+    });
+  });
+});
+
+test("env override 0/false disables regardless of config", () => {
+  withTmpHome((tmp) => {
+    const on = () => ({ liveUsage: true });
+    withEnv("0", () => {
+      assert(
+        isEnabled({ home: tmp, configReader: on }) === false,
+        "expected false for 0",
+      );
+    });
+    withEnv("false", () => {
+      assert(
+        isEnabled({ home: tmp, configReader: on }) === false,
+        "expected false for false",
+      );
+    });
+  });
+});
+
+test("empty env falls through to config", () => {
+  withTmpHome((tmp) => {
+    withEnv("", () => {
+      assert(
+        isEnabled({ home: tmp, configReader: () => ({ liveUsage: true }) }) ===
+          true,
+        "expected config fallthrough",
+      );
+    });
+  });
+});
+
+// ── currentLiveUsage / setLiveUsage ──────────────────
+
+test("currentLiveUsage defaults to off", () => {
+  withTmpHome((tmp) => {
+    assert(currentLiveUsage({ home: tmp }) === false, "expected off");
+  });
+});
+
+test("setLiveUsage persists and currentLiveUsage reads it", () => {
+  withTmpHome((tmp) => {
+    setLiveUsage("on", { home: tmp });
+    assert(currentLiveUsage({ home: tmp }) === true, "expected on");
+    setLiveUsage("off", { home: tmp });
+    assert(currentLiveUsage({ home: tmp }) === false, "expected off");
+  });
+});
+
+test("setLiveUsage rejects invalid value", () => {
+  withTmpHome((tmp) => {
+    let threw = false;
+    try {
+      setLiveUsage("yes", { home: tmp });
+    } catch {
+      threw = true;
+    }
+    assert(threw, "expected throw");
+  });
+});
+
+// ── summary ──────────────────────────────────────────
+
+console.log();
+if (failed > 0) {
+  console.log(`\x1b[38;5;167m${failed} test(s) failed\x1b[0m`);
+  process.exit(1);
+} else {
+  console.log("\x1b[38;5;114mall tests passed\x1b[0m");
+}

--- a/test/measure-width.js
+++ b/test/measure-width.js
@@ -50,6 +50,16 @@ const lines = render(worstCase, {
   },
   // Pin the lamp glyph and skip a real status peek/spawn under test.
   claudeStatus: { status: "major_outage" },
+  liveUsage: {
+    scoped: { label: "Fable", percent: 100, resetsAt: crossDayEpoch() },
+    spend: {
+      usedMinor: 100000,
+      limitMinor: 100000,
+      percent: 100,
+      exponent: 2,
+      currency: "USD",
+    },
+  },
 });
 
 function stripAnsi(str) {


### PR DESCRIPTION
## Summary

- Adds an opt-in line 8 that surfaces usage data absent from the statusline stdin payload: the per-model weekly window (e.g. Fable) alongside extra usage credit spend (`$used/$limit (%)`). The data comes from the same undocumented OAuth usage endpoint the Claude Code `/usage` panel uses internally, which is the only channel that exposes extra credit spend (tracked upstream as anthropics/claude-code#13585, still open). It is **off by default** because it reads the user's OAuth credentials rather than a public registry.
- Credential handling is read-only and minimal: the token is read from the macOS Keychain or `.credentials.json` (under `~/.claude` or `CLAUDE_CONFIG_DIR`), used solely for that single request, and **never written to the cache or logs**. The refresh runs in a detached process with `stdio: "ignore"`, caches only the display fields under `~/.claude/.cache/`, runs at most once every 5 minutes, and backs off for 30 minutes on HTTP 429. Rendering only ever reads the cache, so it never blocks.
- Factors the cache, spawn, and fetch machinery shared with `update-check.js` and `claude-status.js` into a new `lib/bg-cache.js` rather than adding a third copy.

## Design

```mermaid
flowchart LR
  R[statusline render] -->|reads cache only, never blocks| C[(cache: live-usage.json)]
  R -. if stale and not in cooldown .-> S[spawn detached __live-usage]
  S --> T[read OAuth token<br/>keychain or .credentials.json]
  T --> F[GET /api/oauth/usage]
  F -->|extract scoped + spend only| C
```

The token stays in memory for the single request and never reaches the cache; only the extracted `scoped` and `spend` display fields are persisted.

## Changes

- `lib/bg-cache.js` (new) — shared `readCache` / `writeCache` / `isStale` / `spawnDetached` / `fetchJson` helpers. `update-check.js` and `claude-status.js` now delegate to it instead of each carrying their own copy.
- `lib/live-usage.js` (new) — token reading (keychain / file), the OAuth usage fetch, response reduction to `{ scoped, spend }` (prefers `spend{}`, falls back to `extra_usage{}`), the background check with 429 cooldown, the opt-in toggle (config key `liveUsage` plus `CLAUDE_STATUSLINE_LIVE_USAGE` env override), and `peekLiveUsage` for the render path.
- `lib/statusline.js` — render line 8 gated on opt-in **and** at least one segment having data, reusing the existing bar / color / reset-time helpers plus a currency-aware money formatter for the credit segment.
- `bin/claude-code-statusline.js` — `live-usage` subcommand and the `__live-usage` detached-fetch dispatch.
- `commands/live-usage.md` (new) — plugin slash command mirroring the update-check command.
- `scripts/uninstall.sh` — remove the live-usage cache file on uninstall.
- `README.md` / `README.zh-TW.md` / `README.ja.md` — feature bullet, a Live Usage section (credential sources, single-request read, token never persisted, first-run macOS Keychain prompt, env precedence), layout table extended to up to 8 lines, and the color-zone note broadened to include the live usage bar.
- `test/live-usage.js` (new), `test/cli.js`, `test/measure-width.js` — toggle / env / token / extract / peek / background unit tests, render tests for the double gate and money formatting, and the line-8 worst-case width check. Test fixtures use synthetic values only.

## Test plan

Locally executable:

- [x] `npm run check` — lint (js / sh / yml) plus format check plus width check plus all test files. All pass.
- [x] `node test/live-usage.js` — toggle, env override, token reading (keychain / file / `CLAUDE_CONFIG_DIR` / malformed), response extraction, peek gating and cooldown, and background fetch including the assertion that the token is never cached.
- [x] `node test/cli.js` — live usage render tests (hidden when off, scoped plus spend, spend alone, env override) and the `live-usage` CLI toggle.
- [x] `node test/measure-width.js --check` — line 8 worst case stays within 80 columns.

Requires external verification:

- [x] Enable on a real account (`claude-code-statusline live-usage on`) and confirm line 8 renders live data and that the first macOS background fetch shows the one-time Keychain authorization prompt. Confirmed on this machine during development.
- [ ] Regenerate `assets/claude-code-statusline-simulation.png` — the worst-case screenshot still shows 7 lines and needs re-capturing with line 8 present.
