### PR TITLE
Omit duplicate weekly reset time from live usage scoped segment

### DIFF
--- a/lib/statusline.js
+++ b/lib/statusline.js
@@ -741,15 +741,11 @@ function render(data, options = {}) {
       ? options.liveUsage
       : liveUsage.peekLiveUsage({ home, configReader: cfgReader });
   const liveParts = [];
+  // The scoped weekly window shares its reset with the "weekly" window above,
+  // so its reset time is omitted here to avoid repeating the same value.
   if (live?.scoped) {
     liveParts.push(
-      fmtRate(
-        {
-          used_percentage: live.scoped.percent,
-          resets_at: live.scoped.resetsAt,
-        },
-        live.scoped.label,
-      ),
+      fmtRate({ used_percentage: live.scoped.percent }, live.scoped.label),
     );
   }
   if (live?.spend) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -1236,6 +1236,10 @@ test("live usage line renders scoped and spend when enabled", () => {
     assert(out.includes("Fable"), `missing scoped segment: ${out}`);
     assert(out.includes("0%"), "missing scoped percent");
     assert(out.includes("$0.00/$50.00 (0%)"), `missing spend segment: ${out}`);
+    assert(
+      out.includes("0% │ extra"),
+      `scoped segment must not repeat the weekly reset time: ${out}`,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- The live usage scoped segment (per-model weekly window, e.g. Fable) repeated the exact reset time already shown on the `weekly` window one line above, because a model-scoped weekly window resets together with the overall weekly window. The duplicated timestamp added visual noise without carrying new information.
- Drops the reset time from the scoped segment and keeps its per-model percent, which is the segment's only unique data. The `weekly` window still shows the reset.

## Changes

- `lib/statusline.js` — the scoped segment now passes only `used_percentage` to `fmtRate`, so no reset time is rendered. A comment records why it duplicates the `weekly` window.
- `test/cli.js` — the scoped-plus-spend render test now asserts the percent is followed directly by the separator (`0% │ extra`) and locks in the absence of a repeated reset time.

The scoped `resetsAt` stays captured in the cache and covered by `test/live-usage.js`; the data layer is unchanged and only the display drops it.

## Test plan

Locally executable:

- [x] `npm run check` — lint plus format plus width plus all test files. All pass.
- [x] `node test/cli.js` — live usage render tests including the new assertion that the scoped segment does not repeat the weekly reset time.

Requires external verification:

- [x] Render with a real account cache and confirm line 8 shows the per-model percent with no reset time while the `weekly` window keeps its reset. Confirmed on this machine during development.
