### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-statusline",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "author": {
     "name": "Cliff Wu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@z80020100/claude-code-statusline",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@z80020100/claude-code-statusline",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Custom status line for Claude Code — model info, context usage gradient bar, token stats, cost, git status, and rate limits",
   "main": "lib/statusline.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump package version from 1.3.2 to 1.4.0

## Highlights since v1.3.2

- Add an opt-in live usage line (line 8) showing the per-model weekly window (e.g. Fable) and extra usage credit spend, sourced from the OAuth usage endpoint and refreshed in a cached background process. Off by default.
- Omit the weekly reset time from the live usage scoped segment since it duplicates the weekly window shown above it.

## Test plan

- [x] `npm run check` passes (lint + format + width + tests including the version-consistency guard)
